### PR TITLE
Document Gitflow branch requirements for agents

### DIFF
--- a/.agents/skills/abo-abs-tests/SKILL.md
+++ b/.agents/skills/abo-abs-tests/SKILL.md
@@ -14,10 +14,11 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 ## Workflow
 
 1. Determine whether the change affects ABS discovery, path mapping, metadata mode, scan triggering, import/organize behavior, mounted-library behavior, or ABS-facing web/API flows.
-2. Update `test/abs/test-matrix.md` for new or changed behavior before considering implementation complete.
-3. Preserve the reset contract: stop containers, rebuild runtime fixtures, restore committed baseline config, start containers, and scan.
-4. Never restore SQLite state while ABS containers are running.
-5. Prefer focused `go test -tags=abs_e2e ./test/abs/e2e -run TestName -count=1 -v`, then `make abs-test-matrix` when practical.
-6. If Docker, downloads, or certificates block validation, report the exact command and blocker.
+2. Confirm `git status --short --branch` shows a dedicated non-`master` issue branch before editing ABS harness, matrix, or workflow files.
+3. Update `test/abs/test-matrix.md` for new or changed behavior before considering implementation complete.
+4. Preserve the reset contract: stop containers, rebuild runtime fixtures, restore committed baseline config, start containers, and scan.
+5. Never restore SQLite state while ABS containers are running.
+6. Prefer focused `go test -tags=abs_e2e ./test/abs/e2e -run TestName -count=1 -v`, then `make abs-test-matrix` when practical.
+7. If Docker, downloads, or certificates block validation, report the exact command and blocker.
 
 ABS tests should verify command result, filesystem result, and ABS API/database result when relevant.

--- a/.agents/skills/abo-bugfix/SKILL.md
+++ b/.agents/skills/abo-bugfix/SKILL.md
@@ -14,11 +14,12 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 ## Workflow
 
 1. Confirm or create the tracking issue with `$abo-issue-create` logic.
-2. Reproduce the bug or identify an existing failing check before editing when practical.
-3. Locate the smallest responsible package boundary.
-4. Fix the root cause without unrelated cleanup.
-5. Add or update regression coverage.
-6. Update docs, `CHANGELOG.md`, or `test/abs/test-matrix.md` when the fix changes user-visible or ABS-facing behavior.
-7. Run the focused failing check, then the relevant repo-native checks.
+2. Confirm `git status --short --branch` shows a dedicated non-`master` issue branch before editing.
+3. Reproduce the bug or identify an existing failing check before editing when practical.
+4. Locate the smallest responsible package boundary.
+5. Fix the root cause without unrelated cleanup.
+6. Add or update regression coverage.
+7. Update docs, `CHANGELOG.md`, or `test/abs/test-matrix.md` when the fix changes user-visible or ABS-facing behavior.
+8. Run the focused failing check, then the relevant repo-native checks.
 
 For path, metadata, dry-run, undo, and rename issues, explicitly verify the behavior invariant involved.

--- a/.agents/skills/abo-docs/SKILL.md
+++ b/.agents/skills/abo-docs/SKILL.md
@@ -14,10 +14,11 @@ Read `AGENTS.md` and `references/abo-assistant/common.md`.
 ## Workflow
 
 1. Identify whether the change affects user docs, maintainer workflow, repo-local skills, `CHANGELOG.md`, or PR text.
-2. Keep `AGENTS.md` focused on durable repo rules and route repeatable procedures into `.agents/skills/abo-*` or `references/abo-assistant/`.
-3. Update `CHANGELOG.md` under `Unreleased` for user-visible docs, behavior, tooling, runtime, or workflow changes.
-4. Keep command examples repo-native and current.
-5. Avoid documenting unsupported or obsolete UI paths.
-6. Run Markdown/frontmatter consistency checks where practical; Go tests are not required for docs-only changes unless code changed.
+2. Confirm `git status --short --branch` shows a dedicated non-`master` issue branch before editing non-trivial docs.
+3. Keep `AGENTS.md` focused on durable repo rules and route repeatable procedures into `.agents/skills/abo-*` or `references/abo-assistant/`.
+4. Update `CHANGELOG.md` under `Unreleased` for user-visible docs, behavior, tooling, runtime, or workflow changes.
+5. Keep command examples repo-native and current.
+6. Avoid documenting unsupported or obsolete UI paths.
+7. Run Markdown/frontmatter consistency checks where practical; Go tests are not required for docs-only changes unless code changed.
 
 When docs describe verification, include exact commands and note when checks are conditional.

--- a/.agents/skills/abo-feature/SKILL.md
+++ b/.agents/skills/abo-feature/SKILL.md
@@ -14,11 +14,12 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 ## Workflow
 
 1. Confirm or create the tracking issue with `$abo-issue-create` logic.
-2. Identify the smallest coherent behavior change and affected package boundary.
-3. Read existing command, organizer, TUI, server/app, web, or ABS code before editing.
-4. Prefer existing patterns and helpers over new abstractions.
-5. Add or update tests that prove the new behavior.
-6. Update docs, `CHANGELOG.md`, and `test/abs/test-matrix.md` when applicable.
-7. Run focused verification, then wider checks when practical.
+2. Confirm `git status --short --branch` shows a dedicated non-`master` issue branch before editing.
+3. Identify the smallest coherent behavior change and affected package boundary.
+4. Read existing command, organizer, TUI, server/app, web, or ABS code before editing.
+5. Prefer existing patterns and helpers over new abstractions.
+6. Add or update tests that prove the new behavior.
+7. Update docs, `CHANGELOG.md`, and `test/abs/test-matrix.md` when applicable.
+8. Run focused verification, then wider checks when practical.
 
 Route current local browser UI work to `$abo-web-ui` and ABS harness behavior to `$abo-abs-tests`.

--- a/.agents/skills/abo-feature/SKILL.md
+++ b/.agents/skills/abo-feature/SKILL.md
@@ -21,5 +21,6 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 6. Add or update tests that prove the new behavior.
 7. Update docs, `CHANGELOG.md`, and `test/abs/test-matrix.md` when applicable.
 8. Run focused verification, then wider checks when practical.
+9. Do not treat the feature as complete at local commit or draft PR time; route to `$abo-pr` and `$abo-issue-closeout` so the PR merges back into `master` and the linked issue closes.
 
 Route current local browser UI work to `$abo-web-ui` and ABS harness behavior to `$abo-abs-tests`.

--- a/.agents/skills/abo-issue-closeout/SKILL.md
+++ b/.agents/skills/abo-issue-closeout/SKILL.md
@@ -18,7 +18,9 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 3. Add missing `CHANGELOG.md`, docs, or `test/abs/test-matrix.md` updates when required.
 4. Comment on the issue with what changed, tests run, and any follow-up work.
 5. If a PR will close the issue, ensure the PR body uses `Resolves #<issue>` and do not manually close it.
-6. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
-7. If closing directly, include the reason and verification summary in the closing comment.
+6. Treat the issue as open until the resolving PR is ready, required checks and review are satisfied, and the PR has merged back into `master`.
+7. After merge, confirm the linked issue closed and the feature branch or worktree was cleaned up.
+8. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
+9. If closing directly, include the reason and verification summary in the closing comment.
 
 Do not close an issue with failing or unrun required checks unless the user explicitly accepts the risk and the reason is documented.

--- a/.agents/skills/abo-issue-closeout/SKILL.md
+++ b/.agents/skills/abo-issue-closeout/SKILL.md
@@ -14,10 +14,11 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 ## Workflow
 
 1. Run `$abo-issue-verify` logic first: issue criteria, branch diff, tests, docs, changelog, and ABS matrix.
-2. Add missing `CHANGELOG.md`, docs, or `test/abs/test-matrix.md` updates when required.
-3. Comment on the issue with what changed, tests run, and any follow-up work.
-4. If a PR will close the issue, ensure the PR body uses `Resolves #<issue>` and do not manually close it.
-5. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
-6. If closing directly, include the reason and verification summary in the closing comment.
+2. Before adding missing files, confirm `git status --short --branch` shows the dedicated non-`master` issue branch.
+3. Add missing `CHANGELOG.md`, docs, or `test/abs/test-matrix.md` updates when required.
+4. Comment on the issue with what changed, tests run, and any follow-up work.
+5. If a PR will close the issue, ensure the PR body uses `Resolves #<issue>` and do not manually close it.
+6. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
+7. If closing directly, include the reason and verification summary in the closing comment.
 
 Do not close an issue with failing or unrun required checks unless the user explicitly accepts the risk and the reason is documented.

--- a/.agents/skills/abo-issue-create/SKILL.md
+++ b/.agents/skills/abo-issue-create/SKILL.md
@@ -17,8 +17,11 @@ Read `AGENTS.md` and `references/abo-assistant/common.md`.
 2. Search existing issues with `gh issue list --state all --search "<keywords>"`.
 3. Reuse a matching open issue when one exists; otherwise create one with goal, motivation, and acceptance criteria.
 4. Comment on the issue when scope or branch setup needs to be recorded.
-5. Create a dedicated branch from `master` or `origin/master`. Do not branch from a dirty feature branch unless the user explicitly asks.
-6. If the current checkout is dirty with unrelated work, use a separate `git worktree` for the new issue branch.
-7. End with the issue number, branch name, and smallest verifiable goal.
+5. Choose a branch name with the correct prefix: `feature/<short-name>`, `fix/<short-name>`, `docs/<short-name>`, or `chore/<short-name>`.
+6. Create the dedicated branch from `origin/master` after `git fetch origin master`. Do not branch from a dirty feature branch unless the user explicitly asks.
+7. Verify the active branch with `git status --short --branch` before editing.
+8. If the current checkout is dirty with unrelated work, use a separate `git worktree` for the new issue branch.
+9. When creating a separate worktree and hook config exists, run `prek install --hook-type pre-commit --hook-type commit-msg` inside that worktree.
+10. End with the issue number, branch name, and smallest verifiable goal.
 
 Prefer issue titles that describe the user-visible or maintainer-visible outcome. Keep acceptance criteria concrete enough for `$abo-issue-verify`.

--- a/.agents/skills/abo-issue-verify/SKILL.md
+++ b/.agents/skills/abo-issue-verify/SKILL.md
@@ -20,6 +20,7 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 5. Check whether `CHANGELOG.md` is required and present.
 6. Check whether `test/abs/test-matrix.md` is required and present for ABS-facing changes.
 7. Run or confirm the narrowest relevant verification commands, widening when practical.
-8. Report a checklist of pass/fail/blocked items and the exact remaining work.
+8. Verify whether the work is only locally complete or fully closed out through a PR merge back into `master`.
+9. Report a checklist of pass/fail/blocked items and the exact remaining work.
 
 Do not mark the issue done just because tests pass. Tie completion back to acceptance criteria and repo workflow obligations.

--- a/.agents/skills/abo-pr-create/SKILL.md
+++ b/.agents/skills/abo-pr-create/SKILL.md
@@ -14,6 +14,7 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 ## Preconditions
 
 - Do not create PRs from `master`, `main`, `develop`, or `dev`.
+- Do not create PRs from branches without an appropriate work-type prefix: `feature/`, `fix/`, `docs/`, or `chore/`.
 - Do not include unrelated dirty worktree changes.
 - Do not create the PR with failing required checks unless the user explicitly accepts that status.
 
@@ -24,9 +25,11 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 3. Confirm or create the PR body using `$abo-pr-writer`.
 4. Run or confirm relevant checks from `references/abo-assistant/testing.md`, including `prek run --all-files` when pre-commit hooks are configured.
 5. Stage only intended files.
-6. Commit with a concise message tied to the issue.
-7. Push the branch and set upstream.
-8. Create a draft PR with `gh pr create --base master --head <branch> --draft --body-file <file>`.
-9. Verify the PR URL and draft state before reporting success.
+6. Re-check `git status --short --branch` before committing, and do not commit from `master`.
+7. Commit with a concise message tied to the issue.
+8. Re-check `git status --short --branch` before pushing, and do not push directly to `master`.
+9. Push the branch and set upstream.
+10. Create a draft PR with `gh pr create --base master --head <branch> --draft --body-file <file>`.
+11. Verify the PR URL and draft state before reporting success.
 
 End with the PR URL, tests run, and any checks still pending.

--- a/.agents/skills/abo-pr-watcher/SKILL.md
+++ b/.agents/skills/abo-pr-watcher/SKILL.md
@@ -20,6 +20,7 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 5. Before applying fixes, confirm `git status --short --branch` shows the PR branch and not `master`.
 6. Apply mechanical or clearly requested fixes; ask before behavior changes or risky rebases.
 7. Run the narrowest relevant checks after fixes.
-8. Summarize what changed, what remains blocked, and what should rerun.
+8. When checks and review are clean, report whether the PR is ready to merge back into `master` and whether the linked issue will close.
+9. Summarize what changed, what remains blocked, and what should rerun.
 
 Do not dismiss failures as flaky without evidence.

--- a/.agents/skills/abo-pr-watcher/SKILL.md
+++ b/.agents/skills/abo-pr-watcher/SKILL.md
@@ -17,8 +17,9 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 2. Inspect PR state, checks, review comments, issue comments, and branch freshness.
 3. Classify findings as CI failure, requested change, maintainer question, docs/changelog gap, stale branch, or follow-up.
 4. Inspect failed logs with `gh run view --log-failed` when available.
-5. Apply mechanical or clearly requested fixes; ask before behavior changes or risky rebases.
-6. Run the narrowest relevant checks after fixes.
-7. Summarize what changed, what remains blocked, and what should rerun.
+5. Before applying fixes, confirm `git status --short --branch` shows the PR branch and not `master`.
+6. Apply mechanical or clearly requested fixes; ask before behavior changes or risky rebases.
+7. Run the narrowest relevant checks after fixes.
+8. Summarize what changed, what remains blocked, and what should rerun.
 
 Do not dismiss failures as flaky without evidence.

--- a/.agents/skills/abo-pr/SKILL.md
+++ b/.agents/skills/abo-pr/SKILL.md
@@ -18,5 +18,6 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 - Existing PR status, comments, checks, or requested changes: `$abo-pr-watcher`.
 - Issue completion checks before PR: `$abo-issue-verify`.
 - Final issue/changelog/docs hygiene: `$abo-issue-closeout`.
+- Finished feature, fix, docs, or chore branch: verify checks, get the PR ready, merge back into `master`, confirm the issue closed, and clean up the branch or worktree.
 
 If intent is unclear, ask whether the user wants PR text, PR creation, PR status watching, or closeout verification.

--- a/.agents/skills/abo-tests/SKILL.md
+++ b/.agents/skills/abo-tests/SKILL.md
@@ -15,10 +15,11 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 
 1. Identify the behavior under test and affected package boundary.
 2. Find nearby tests before adding new ones.
-3. For bug fixes, create or identify a failing check first when practical.
-4. Prefer focused package tests, then widen to repo-native checks.
-5. Run `prek run --all-files` when pre-commit hooks are configured.
-6. Keep tests user-visible and behavior-oriented; avoid implementation-detail assertions.
-7. Report exact commands, status, and blockers.
+3. Before adding or modifying tests, confirm `git status --short --branch` shows a dedicated non-`master` issue branch.
+4. For bug fixes, create or identify a failing check first when practical.
+5. Prefer focused package tests, then widen to repo-native checks.
+6. Run `prek run --all-files` when pre-commit hooks are configured.
+7. Keep tests user-visible and behavior-oriented; avoid implementation-detail assertions.
+8. Report exact commands, status, and blockers.
 
 Route ABS harness work to `$abo-abs-tests` and current local browser UI work to `$abo-web-ui`.

--- a/.agents/skills/abo-updater/SKILL.md
+++ b/.agents/skills/abo-updater/SKILL.md
@@ -14,7 +14,7 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 ## Workflow
 
 1. Confirm the update scope: security fix, specific dependency, Go dependencies, web dependencies, or all dependencies.
-2. Inspect current branch and worktree status. Use an issue branch for non-trivial updates.
+2. Confirm `git status --short --branch` shows a dedicated non-`master` issue branch before non-trivial dependency updates.
 3. Prefer targeted updates for vulnerabilities or requested packages.
 4. For Go updates, run the chosen `go get` command, then `go mod tidy`.
 5. For web updates, update only `web/` dependencies.

--- a/.agents/skills/abo-web-ui/SKILL.md
+++ b/.agents/skills/abo-web-ui/SKILL.md
@@ -14,11 +14,12 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 ## Workflow
 
 1. Confirm the checkout contains the current `web/` frontend. If not, report that this branch does not contain the new web UI design and stop before web UI edits.
-2. Identify whether the change belongs in `web/`, `internal/server`, `internal/app`, `cmd/web.go`, or `cmd/gui.go`.
-3. Preserve loopback-only server behavior and session token checks.
-4. Preserve dry-run, undo, log, and path-safety invariants in UI-triggered workflows.
-5. Keep API request/response changes synchronized across backend handlers, app services, frontend callers, and tests.
-6. Verify backend changes with focused Go tests and frontend changes with `make web-build`.
-7. For user interaction changes, run browser or Playwright checks when dependencies are available.
+2. Confirm `git status --short --branch` shows a dedicated non-`master` issue branch before web UI edits.
+3. Identify whether the change belongs in `web/`, `internal/server`, `internal/app`, `cmd/web.go`, or `cmd/gui.go`.
+4. Preserve loopback-only server behavior and session token checks.
+5. Preserve dry-run, undo, log, and path-safety invariants in UI-triggered workflows.
+6. Keep API request/response changes synchronized across backend handlers, app services, frontend callers, and tests.
+7. Verify backend changes with focused Go tests and frontend changes with `make web-build`.
+8. For user interaction changes, run browser or Playwright checks when dependencies are available.
 
 Keep this skill focused on the current local browser UI paths only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,9 @@ Shared skill references live in `references/abo-assistant/`. Keep AGENTS.md focu
 
 - Track non-trivial code and documentation changes with a GitHub issue before editing files.
 - If an issue already exists, use it. If not, create one with the goal, motivation, and acceptance criteria.
-- Create a dedicated branch from `master` for each issue. Use a descriptive branch name such as `feature/download-search-results` or `fix/series-metadata`.
+- Create a dedicated branch from `master` for each issue before editing files. Start from a fresh remote base with `git fetch origin master` and `git switch -c <branch> origin/master`.
+- Use descriptive branch prefixes by work type: `feature/<short-name>` for features, `fix/<short-name>` for bug fixes, `docs/<short-name>` for documentation-only changes, and `chore/<short-name>` for maintainer/tooling work.
+- Verify the active branch with `git status --short --branch` before editing, committing, or pushing. Do not commit or push from `master` except for explicitly approved tiny edits or explicit repository maintenance such as an approved history rewrite.
 - Keep the issue updated while working. Add comments for scope changes, important implementation decisions, blockers, test results, and follow-up work discovered during implementation.
 - Keep commits focused on the issue. Do not mix unrelated cleanup, refactors, or separate features into the same branch.
 - As part of each feature or fix, decide whether tests, docs, and `CHANGELOG.md` need updates. If they do, include them in the same branch. If they do not, note why in the PR.
@@ -71,10 +73,12 @@ Shared skill references live in `references/abo-assistant/`. Keep AGENTS.md focu
 - Maintain the root `CHANGELOG.md`. User-visible features, fixes, behavior changes, Docker/runtime changes, and documentation changes should add a concise changelog entry under `Unreleased` before the PR is merged.
 - Before opening a PR, run the relevant repo-native checks. If a check cannot be run or has known unrelated failures, document that in the PR.
 - When pre-commit hooks are configured, prefer `prek run --all-files` over `pre-commit run --all-files`. If hooks are installed locally but no config exists on the branch, report that instead of treating hook execution as required.
+- When creating a separate Git worktree, install both pre-commit and commit-message hooks in that worktree when hook config exists, for example `prek install --hook-type pre-commit --hook-type commit-msg`.
 - Open a pull request into `master` when the branch is ready. The PR body must include the issue it resolves, a short summary, tests run, docs/changelog status, and any follow-up issues created.
+- Prefer Squash and merge for PRs unless the maintainer asks for another merge strategy.
 - Issues should close through the PR merge, not through direct commits to `master`.
 - After a PR is merged, delete the remote feature branch and remove the local branch or worktree.
-- Do not push directly to `master` for normal feature or fix work.
+- Do not push directly to `master` for normal feature, fix, docs, or chore work.
 - If work is paused or deferred, leave the issue open and comment with the current state and next step.
 
 Tiny explicitly requested edits may proceed without creating an issue, but do not mix unrelated work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,8 @@ Shared skill references live in `references/abo-assistant/`. Keep AGENTS.md focu
 - When creating a separate Git worktree, install both pre-commit and commit-message hooks in that worktree when hook config exists, for example `prek install --hook-type pre-commit --hook-type commit-msg`.
 - Open a pull request into `master` when the branch is ready. The PR body must include the issue it resolves, a short summary, tests run, docs/changelog status, and any follow-up issues created.
 - Prefer Squash and merge for PRs unless the maintainer asks for another merge strategy.
-- Issues should close through the PR merge, not through direct commits to `master`.
-- After a PR is merged, delete the remote feature branch and remove the local branch or worktree.
+- A feature, fix, docs, or chore issue is not complete at local commit or draft PR time. Close the cycle by getting the PR ready, passing required checks, merging back into `master`, and letting the linked issue close through the PR merge.
+- After the PR is merged, delete the remote feature branch and remove the local branch or worktree.
 - Do not push directly to `master` for normal feature, fix, docs, or chore work.
 - If work is paused or deferred, leave the issue open and comment with the current state and next step.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the deprecated GUI tree and release packaging. Releases now focus on one `audiobook-organizer` binary with CLI, TUI, ABS, and local web UI entrypoints.
 - Rewrote the root README for the single-binary web UI direction and current command surface.
 - Split the Audiobookshelf E2E matrix into parallel GitHub Actions jobs for faster feedback.
-- Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, and branch verification.
+- Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, branch verification, and closeout through merge back to `master`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the deprecated GUI tree and release packaging. Releases now focus on one `audiobook-organizer` binary with CLI, TUI, ABS, and local web UI entrypoints.
 - Rewrote the root README for the single-binary web UI direction and current command surface.
 - Split the Audiobookshelf E2E matrix into parallel GitHub Actions jobs for faster feedback.
+- Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, and branch verification.
 
 ---
 

--- a/references/abo-assistant/common.md
+++ b/references/abo-assistant/common.md
@@ -7,13 +7,16 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - Read `AGENTS.md` first.
 - Default branch is `master`.
 - Non-trivial code or documentation work needs a GitHub issue before edits.
-- Work on a dedicated branch from `master`; do not push directly to `master`.
+- Work on a dedicated branch from `origin/master` before editing; do not push directly to `master`.
+- Use branch prefixes by work type: `feature/<short-name>`, `fix/<short-name>`, `docs/<short-name>`, or `chore/<short-name>`.
+- Verify `git status --short --branch` before editing, committing, or pushing.
+- If a separate Git worktree is created and hook config exists, run `prek install --hook-type pre-commit --hook-type commit-msg` inside that worktree.
 - Preserve unrelated dirty worktree changes.
 - Keep edits focused on the issue.
 - Keep the issue updated with decisions, blockers, test results, and follow-up work.
 - User-visible features, fixes, behavior changes, Docker/runtime changes, and documentation changes need a `CHANGELOG.md` entry under `Unreleased`.
 - ABS-facing behavior changes must update `test/abs/test-matrix.md` unless explicitly not applicable.
-- PRs target `master`; issues normally close through PR merge.
+- PRs target `master`; prefer Squash and merge; issues normally close through PR merge.
 
 ## Architecture Map
 
@@ -56,5 +59,6 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - `git fetch origin master`
 - `git switch -c <branch> origin/master`
 - `git status --short --branch`
+- `prek install --hook-type pre-commit --hook-type commit-msg`
 
 Prefer `rg` for content search and `fd` or `find` for file discovery.

--- a/references/abo-assistant/common.md
+++ b/references/abo-assistant/common.md
@@ -17,6 +17,7 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - User-visible features, fixes, behavior changes, Docker/runtime changes, and documentation changes need a `CHANGELOG.md` entry under `Unreleased`.
 - ABS-facing behavior changes must update `test/abs/test-matrix.md` unless explicitly not applicable.
 - PRs target `master`; prefer Squash and merge; issues normally close through PR merge.
+- Do not treat a local commit or draft PR as done. Finish the cycle by getting the PR ready, passing required checks, merging back into `master`, confirming the linked issue closed, and cleaning up the branch or worktree.
 
 ## Architecture Map
 

--- a/references/abo-assistant/pr.md
+++ b/references/abo-assistant/pr.md
@@ -37,7 +37,8 @@ Prefer Squash and merge when the PR is ready unless the maintainer asks for anot
 
 ## Closeout Rules
 
-- Issues normally close through PR merge.
+- Issues normally close through PR merge back into `master`.
+- A branch is not done when implementation is committed, pushed, or opened as a draft PR. Closeout means the PR is ready, required checks and review are satisfied, the PR is merged, the linked issue closes, and stale branches or worktrees are cleaned up.
 - Use closing keywords in the PR body when the PR fully resolves the issue.
 - Directly close an issue only when the user explicitly asks, the issue is obsolete/duplicate, or the work intentionally completed outside PR merge.
 - Before closeout, verify acceptance criteria against code, tests, docs, changelog, and PR state.

--- a/references/abo-assistant/pr.md
+++ b/references/abo-assistant/pr.md
@@ -5,6 +5,7 @@ Use this shared reference for PR writing, creation, watching, and closeout.
 ## PR Preconditions
 
 - Branch is not `master`, `main`, `develop`, or `dev`.
+- Branch uses the appropriate work-type prefix: `feature/`, `fix/`, `docs/`, or `chore/`.
 - Branch is tied to a GitHub issue.
 - Unrelated dirty worktree changes are not included.
 - Relevant tests, lint, and builds have been run or explicitly documented as blocked.
@@ -32,6 +33,7 @@ Prefer concise reviewer-oriented text. Do not hide unrun tests.
 - `gh pr create --base master --head <branch> --draft --title "<title>" --body-file <file>`
 
 Prefer `--body-file` over `--fill` so issue links, test notes, and changelog status are preserved.
+Prefer Squash and merge when the PR is ready unless the maintainer asks for another merge strategy.
 
 ## Closeout Rules
 

--- a/references/abo-assistant/testing.md
+++ b/references/abo-assistant/testing.md
@@ -15,6 +15,7 @@ Use repo-native checks first. Start narrow, then widen before PR closeout when p
 - Direct package tests: `go test ./internal/organizer/...`
 - Focused test: `go test -run TestName ./path/to/package`
 - Pre-commit hooks, when configured: `prek run --all-files`
+- New worktree hook setup, when configured: `prek install --hook-type pre-commit --hook-type commit-msg`
 
 Prefer `prek` over `pre-commit`. If no `.pre-commit-config.yaml` or `.pre-commit-config.yml` exists on the branch, report that pre-commit hooks are not configured rather than forcing the command.
 


### PR DESCRIPTION
Resolves #45

## Summary
- Clarify AGENTS.md Gitflow rules for issue branches, branch prefixes, branch verification, worktree hook setup, and Squash and merge preference.
- Make completion explicit: local commits and draft PRs are not done until the PR is ready, checks pass, it merges back into master, the linked issue closes, and the branch/worktree is cleaned up.
- Update shared agent references and repo-local feature, PR, issue verification, and issue closeout skills to carry the same closeout-cycle guidance.
- Add an Unreleased changelog entry for the maintainer workflow documentation update.

## Tests
- git diff --check
- prek run --all-files

## Docs / Changelog / ABS
- Docs and repo-local skills updated.
- CHANGELOG.md updated under Unreleased.
- ABS matrix not applicable; this is maintainer workflow documentation only.