### PR TITLE
Add ABS smoke reset matrix coverage

### DIFF
--- a/.agents/skills/abo-workflow/SKILL.md
+++ b/.agents/skills/abo-workflow/SKILL.md
@@ -11,6 +11,15 @@ You are the Audiobook Organizer workflow coordinator.
 
 Read `AGENTS.md` and `references/abo-assistant/common.md`.
 
+## Intake
+
+When the user asks to start, pick, or work through repository issues but does not name a specific issue or task, ask whether they want to:
+
+- create a new feature/fix idea, then route through `$abo-issue-create`;
+- choose from the existing GitHub issue list, then route through `$abo-issue-watcher`.
+
+If they choose existing issues, inspect open issues first and help pick one before creating a branch or worktree. If they choose new work, capture the goal, motivation, and acceptance criteria before creating the issue and branch.
+
 ## Route
 
 - New tracked work or branch setup: `$abo-issue-create`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: smoke-reset
+            run_regex: TestABSHarnessSmokeResetContract
           - name: metadata-json
             run_regex: TestMetadataJSONMode
           - name: embedded-already-indexed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the deprecated GUI tree and release packaging. Releases now focus on one `audiobook-organizer` binary with CLI, TUI, ABS, and local web UI entrypoints.
 - Rewrote the root README for the single-binary web UI direction and current command surface.
 - Split the Audiobookshelf E2E matrix into parallel GitHub Actions jobs for faster feedback.
+- Added a first-class Audiobookshelf smoke/reset matrix row for the reset, baseline restore, startup, scan, metadata setting, and initial item count contract.
 - Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, branch verification, and closeout through merge back to `master`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split the Audiobookshelf E2E matrix into parallel GitHub Actions jobs for faster feedback.
 - Added a first-class Audiobookshelf smoke/reset matrix row for the reset, baseline restore, startup, scan, metadata setting, and initial item count contract.
 - Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, branch verification, and closeout through merge back to `master`.
+- Refined the `abo-workflow` skill to prompt between creating new tracked work and selecting from existing GitHub issues.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LDFLAGS := -ldflags "-s -w $(VERSION_FLAGS)"
 # Test packages
 UNIT_TEST_PKGS = ./...
 INTEGRATION_TEST_PKGS = $(shell go list ./... | grep -v '/integration$$')
-ABS_TEST_RUN ?= Test(MetadataJSONMode|EmbeddedAlreadyIndexed|EmbeddedMetadataImport|FlatModeImport|RESTHarness_(MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle)
+ABS_TEST_RUN ?= Test(ABSHarnessSmokeResetContract|MetadataJSONMode|EmbeddedAlreadyIndexed|EmbeddedMetadataImport|FlatModeImport|RESTHarness_(MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle)
 ABS_REST_TEST_RUN ?= TestRESTHarness_(MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle
 
 .PHONY: all build clean dev dev-linux-amd64 web-install web-build web-dev gui-rest-test gui-test gui-test-headed gui-test-ui abs-dev-seed abs-dev-init abs-dev-configure abs-dev-up abs-dev-down abs-dev-reset abs-dev-reset-all abs-dev-scan abs-dev-reset-scan abs-ci-smoke abs-test-metadata abs-test-rest abs-test-matrix abs-test-e2e abs-dev-capture-baseline abs-dev-restore-baseline abs-dev-wait release test test-unit test-integration coverage coverage-html lint fmt fmt-check vet help scp-dev

--- a/test/abs/e2e/smoke_test.go
+++ b/test/abs/e2e/smoke_test.go
@@ -1,0 +1,106 @@
+//go:build abs_e2e
+
+package e2e
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+)
+
+type absSmokeCase struct {
+	name              string
+	instance          absInstance
+	library           absLibrary
+	dbParts           []string
+	wantStoreMetadata bool
+	wantItems         int
+}
+
+func TestABSHarnessSmokeResetContract(t *testing.T) {
+	resetAndInitialScan(t)
+
+	for _, tc := range []absSmokeCase{
+		{
+			name:              "plain_audiobooks",
+			instance:          plainInstance,
+			library:           audiobooksLibrary,
+			dbParts:           []string{"test", "abs", "state", "plain", "config", "absdatabase.sqlite"},
+			wantStoreMetadata: false,
+			wantItems:         2,
+		},
+		{
+			name:              "plain_books",
+			instance:          plainInstance,
+			library:           booksLibrary,
+			dbParts:           []string{"test", "abs", "state", "plain", "config", "absdatabase.sqlite"},
+			wantStoreMetadata: false,
+			wantItems:         3,
+		},
+		{
+			name:              "metadata_enabled_audiobooks",
+			instance:          metadataEnabledInstance,
+			library:           audiobooksLibrary,
+			dbParts:           []string{"test", "abs", "state", "metadata-enabled", "config", "absdatabase.sqlite"},
+			wantStoreMetadata: true,
+			wantItems:         2,
+		},
+		{
+			name:              "metadata_enabled_books",
+			instance:          metadataEnabledInstance,
+			library:           booksLibrary,
+			dbParts:           []string{"test", "abs", "state", "metadata-enabled", "config", "absdatabase.sqlite"},
+			wantStoreMetadata: true,
+			wantItems:         3,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := pathFromRoot(tc.dbParts...)
+			gotStoreMetadata := readStoreMetadataWithItem(t, dbPath)
+			if gotStoreMetadata != tc.wantStoreMetadata {
+				t.Fatalf(
+					"storeMetadataWithItem mismatch for %s: got %t, want %t",
+					tc.instance.name,
+					gotStoreMetadata,
+					tc.wantStoreMetadata,
+				)
+			}
+
+			ctx := newABSScenarioContext(t, tc.instance, tc.library)
+			waitForABSState(t, ctx, absStateExpectation{
+				expectedCount: tc.wantItems,
+				missingCount:  0,
+			})
+		})
+	}
+}
+
+func readStoreMetadataWithItem(t *testing.T, dbPath string) bool {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open ABS config database %s: %v", dbPath, err)
+	}
+	defer db.Close()
+
+	var value int
+	if err := db.QueryRow(`
+		select json_extract(value, '$.storeMetadataWithItem')
+		from settings
+		where key = 'server-settings'
+	`).Scan(&value); err != nil {
+		t.Fatalf("read storeMetadataWithItem from %s: %v", dbPath, err)
+	}
+
+	switch value {
+	case 0:
+		return false
+	case 1:
+		return true
+	default:
+		t.Fatalf("unexpected storeMetadataWithItem value in %s: %s", dbPath, fmt.Sprint(value))
+		return false
+	}
+}

--- a/test/abs/test-matrix.md
+++ b/test/abs/test-matrix.md
@@ -120,7 +120,7 @@ specifically about series layout. It gives stable, easy-to-assert paths:
 
 | ID | Mode | Instance | Library | Command shape | Expected result |
 | --- | --- | --- | --- | --- | --- |
-| H1 | Harness smoke | both | both | `make abs-dev-reset-scan` | Both servers reachable; plain has metadata setting `0`; metadata-enabled has metadata setting `1`; both have 2 audiobook items and 3 ebook items. |
+| H1 | Harness smoke | both | both | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSHarnessSmokeResetContract -count=1 -v` | Implemented. Runs `make abs-dev-reset-scan`, verifies both servers are reachable through the ABS API, asserts plain has `storeMetadataWithItem=0`, asserts metadata-enabled has `storeMetadataWithItem=1`, and verifies both instances have exactly 2 audiobook items, 3 ebook items, and 0 missing items after the initial scan. |
 | M1A | `metadata.json` | metadata-enabled | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestMetadataJSONMode_AudiobooksLifecycle -count=1 -v` | Implemented as a table-driven lifecycle row. Moves audiobook directories using sidecar metadata; verifies old files are gone and new files exist; scans ABS; verifies old ABS rows are missing and new organized rows are active; calls the ABS library issues cleanup endpoint; rescans; verifies final ABS state has 2 active organized items and 0 missing items. |
 | M1B | `metadata.json` | metadata-enabled | Ebooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestMetadataJSONMode_BooksLifecycle -count=1 -v` | Implemented as a table-driven lifecycle row. Moves ebook directories using sidecar metadata; verifies old files are gone and new files exist; scans ABS; verifies old ABS rows are missing and new organized rows are active; calls the ABS library issues cleanup endpoint; rescans; verifies final ABS state has 3 active organized items and 0 missing items. |
 | M1C | `metadata.json` negative control | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestMetadataJSONMode_AudiobooksLifecycle -count=1 -v` | Implemented as a table-driven lifecycle row. No `metadata.json` exists, so no files move. Old messy paths remain; ABS scan leaves 2 active original items and 0 missing items. |
@@ -178,6 +178,7 @@ cycle, so the fixed ABS ports do not conflict:
 
 | Row | `ABS_TEST_RUN` |
 | --- | --- |
+| `smoke-reset` | `TestABSHarnessSmokeResetContract` |
 | `metadata-json` | `TestMetadataJSONMode` |
 | `embedded-already-indexed` | `TestEmbeddedAlreadyIndexed` |
 | `embedded-import` | `TestEmbeddedMetadataImport` |


### PR DESCRIPTION
Resolves #30

## Summary

- Added `TestABSHarnessSmokeResetContract` as the first-class H1 ABS smoke/reset test.
- Wired H1 into the default ABS matrix regex and GitHub Actions ABS matrix.
- Marked the H1 row implemented in `test/abs/test-matrix.md` and added a changelog entry.

## Tests

- `make abs-test-matrix ABS_TEST_RUN=TestABSHarnessSmokeResetContract`
- Commit hooks: trailing whitespace, end-of-file, YAML, large files, merge conflicts, private key, mixed line ending, goimports, gofumpt, golines, Conventional Commit.

## Docs / Changelog

- Updated `test/abs/test-matrix.md`.
- Updated `CHANGELOG.md`.

## Notes

- Full ABS matrix was not run locally; the new H1 row is also wired into CI.
