### PR TITLE
Add non-interactive metadata output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audiobookshelf web workflow**: The new web foundation treats ABS as a first-class source alongside local metadata and embedded metadata.
 - **Preview-oriented app service layer**: Added an internal application service that converts web requests into organizer, renamer, and ABS operations without coupling the HTTP layer to Cobra command handling.
 - **REST execution coverage for ABS workflows**: Added Docker-backed REST tests for `metadata.json`, embedded metadata import, and flat import workflows against real Audiobookshelf containers.
+- **Text-only metadata inspection**: `audiobook-organizer metadata` now prints non-interactive metadata scan results, `metadata --json` writes machine-readable output, and `metadata-tui` keeps the old interactive metadata exploration workflow explicit.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Audiobook Organizer is a single-binary tool for cleaning up audiobook libraries.
 The project now ships one `audiobook-organizer` binary with:
 
 - a local browser UI: `audiobook-organizer web`
-- terminal workflows: `audiobook-organizer tui`, `rename-tui`, and `metadata`
-- scriptable CLI workflows: root organize command, `rename`, and `abs`
+- terminal workflows: `audiobook-organizer tui`, `rename-tui`, and `metadata-tui`
+- scriptable CLI workflows: root organize command, `rename`, `metadata`, and `abs`
 
 `audiobook-organizer gui` remains as a compatibility alias for `audiobook-organizer web`.
 
@@ -36,7 +36,8 @@ The project now ships one `audiobook-organizer` binary with:
 | Organization TUI | `audiobook-organizer tui` | Keyboard-first interactive organization | Stable |
 | Rename CLI | `audiobook-organizer rename --dir=/books` | Scriptable file renaming | Stable |
 | Rename TUI | `audiobook-organizer rename-tui --dir=/books` | Interactive rename previews | Stable |
-| Metadata TUI | `audiobook-organizer metadata --dir=/books` | Metadata inspection and template exploration | Stable |
+| Metadata CLI | `audiobook-organizer metadata --dir=/books` | Text-only metadata inspection | Stable |
+| Metadata TUI | `audiobook-organizer metadata-tui --dir=/books` | Metadata inspection and template exploration | Stable |
 | Audiobookshelf CLI | `audiobook-organizer abs ...` | ABS discovery, path mapping, metadata previews, and scan triggers | Active development |
 
 ## Quick Start
@@ -167,8 +168,11 @@ audiobook-organizer tui --dir=/path/to/books --out=/path/to/organized
 # Interactive rename workflow
 audiobook-organizer rename-tui --dir=/path/to/books
 
-# Metadata exploration workflow
+# Text-only metadata inspection
 audiobook-organizer metadata --dir=/path/to/books
+
+# Metadata exploration workflow
+audiobook-organizer metadata-tui --dir=/path/to/books
 ```
 
 See [docs/TUI.md](docs/TUI.md) and [docs/METADATA_COMMAND.md](docs/METADATA_COMMAND.md).

--- a/cmd/metadata.go
+++ b/cmd/metadata.go
@@ -1,32 +1,60 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
-	"github.com/jeeftor/audiobook-organizer/internal/tui"
+	"github.com/jeeftor/audiobook-organizer/internal/organizer"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
+type metadataJSONOutput struct {
+	Files   []metadataJSONFile  `json:"files"`
+	Summary metadataJSONSummary `json:"summary"`
+}
+
+type metadataJSONFile struct {
+	Path        string                 `json:"path"`
+	SourceType  string                 `json:"source_type"`
+	Title       string                 `json:"title"`
+	Authors     []string               `json:"authors"`
+	Series      []string               `json:"series"`
+	TrackNumber int                    `json:"track_number"`
+	TrackTitle  string                 `json:"track_title,omitempty"`
+	Album       string                 `json:"album"`
+	RawData     map[string]interface{} `json:"raw_data,omitempty"`
+	Error       string                 `json:"error,omitempty"`
+}
+
+type metadataJSONSummary struct {
+	FilesScanned int `json:"files_scanned"`
+	Errors       int `json:"errors"`
+}
+
 var metadataCmd = &cobra.Command{
 	Use:   "metadata",
-	Short: "View and explore audiobook metadata",
-	Long: `Launch an interactive terminal UI to view audiobook metadata.
+	Short: "Inspect audiobook metadata non-interactively",
+	Long: `Inspect audiobook metadata without launching the interactive TUI.
 
-The metadata command provides a guided interface to:
-  - Scan directories and view metadata from files
-  - See metadata from both metadata.json and embedded tags
-  - Explore available metadata fields
-  - Build and test rename templates interactively
-  - Customize field mappings for metadata.json files
+The metadata command scans directories and prints extracted metadata in the
+terminal. Use --json for machine-readable output, or metadata-tui for the guided
+terminal workflow.
 
-This command helps you understand what metadata is available in your files
-before organizing or renaming them.
+The output includes each file path, metadata source type, title, authors,
+series, track number, album, and extraction errors when present.
 
 Examples:
-  # View metadata with default settings
+  # Inspect metadata in the terminal
   audiobook-organizer metadata --dir=/path/to/books
+
+  # Inspect metadata as JSON for scripts and CI
+  audiobook-organizer metadata --dir=/path/to/books --json
 
   # Force embedded metadata (ignore metadata.json)
   audiobook-organizer metadata --dir=/path --use-embedded-metadata
@@ -34,71 +62,29 @@ Examples:
   # Flat mode (implies embedded metadata)
   audiobook-organizer metadata --dir=/path --flat
 
+  # Launch the interactive metadata TUI
+  audiobook-organizer metadata-tui --dir=/path/to/books
+
   # Custom field mapping for metadata.json
-  audiobook-organizer metadata --dir=/path \
+  audiobook-organizer metadata --dir=/path --json \
     --title-field=album \
     --author-fields=artist,album_artist`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// Check for required --dir flag - read directly from command flags
-		inputDir, _ := cmd.Flags().GetString("dir")
-		if inputDir == "" {
-			inputDir, _ = cmd.Flags().GetString("input")
-		}
-		// Also check viper for config file values
-		if inputDir == "" {
-			inputDir = viper.GetString("dir")
-		}
-		if inputDir == "" {
-			inputDir = viper.GetString("input")
-		}
-		if inputDir == "" {
-			return fmt.Errorf("--dir must be specified")
+		if metadataInputDir(cmd) == "" {
+			return errMetadataDirRequired()
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		// Get inputDir from command flags first, then viper
-		inputDir, _ := cmd.Flags().GetString("dir")
-		if inputDir == "" {
-			inputDir, _ = cmd.Flags().GetString("input")
-		}
-		if inputDir == "" {
-			inputDir = viper.GetString("dir")
-		}
-		if inputDir == "" {
-			inputDir = viper.GetString("input")
+	RunE: func(cmd *cobra.Command, args []string) error {
+		inputDir := metadataInputDir(cmd)
+		syncMetadataFlagsToViper(cmd, inputDir)
+
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		if jsonOutput {
+			return runMetadataJSON(cmd, inputDir)
 		}
 
-		// Also set viper values for the TUI to use
-		viper.Set("dir", inputDir)
-
-		// Get other flags and set them in viper for TUI
-		useEmbedded, _ := cmd.Flags().GetBool("use-embedded-metadata")
-		flat, _ := cmd.Flags().GetBool("flat")
-		verbose, _ := cmd.Flags().GetBool("verbose")
-
-		viper.Set("use-embedded-metadata", useEmbedded)
-		viper.Set("flat", flat)
-		viper.Set("verbose", verbose)
-
-		// Field mapping flags
-		if titleField, _ := cmd.Flags().GetString("title-field"); titleField != "" {
-			viper.Set("title-field", titleField)
-		}
-		if seriesField, _ := cmd.Flags().GetString("series-field"); seriesField != "" {
-			viper.Set("series-field", seriesField)
-		}
-		if authorFields, _ := cmd.Flags().GetString("author-fields"); authorFields != "" {
-			viper.Set("author-fields", authorFields)
-		}
-		if trackField, _ := cmd.Flags().GetString("track-field"); trackField != "" {
-			viper.Set("track-field", trackField)
-		}
-
-		if err := tui.RunRenameMode(inputDir); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
+		return runMetadataText(cmd, inputDir)
 	},
 }
 
@@ -111,6 +97,7 @@ func init() {
 	metadataCmd.Flags().
 		Bool("use-embedded-metadata", false, "Force use of embedded metadata (ignore metadata.json)")
 	metadataCmd.Flags().Bool("flat", false, "Flat mode (implies --use-embedded-metadata)")
+	metadataCmd.Flags().Bool("json", false, "Write metadata scan results as JSON")
 	metadataCmd.Flags().BoolP("verbose", "v", false, "Verbose output")
 
 	// Field mapping flags (for metadata.json customization)
@@ -127,9 +114,359 @@ func init() {
 	viper.BindPFlag("input", metadataCmd.Flags().Lookup("input"))
 	viper.BindPFlag("use-embedded-metadata", metadataCmd.Flags().Lookup("use-embedded-metadata"))
 	viper.BindPFlag("flat", metadataCmd.Flags().Lookup("flat"))
+	viper.BindPFlag("json", metadataCmd.Flags().Lookup("json"))
 	viper.BindPFlag("verbose", metadataCmd.Flags().Lookup("verbose"))
 	viper.BindPFlag("title-field", metadataCmd.Flags().Lookup("title-field"))
 	viper.BindPFlag("series-field", metadataCmd.Flags().Lookup("series-field"))
 	viper.BindPFlag("author-fields", metadataCmd.Flags().Lookup("author-fields"))
 	viper.BindPFlag("track-field", metadataCmd.Flags().Lookup("track-field"))
+}
+
+func runMetadataJSON(cmd *cobra.Command, inputDir string) error {
+	output, err := scanMetadataJSON(inputDir, metadataUseEmbedded(cmd), metadataFieldMapping(cmd))
+	if err != nil {
+		return err
+	}
+
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(output)
+}
+
+func runMetadataText(cmd *cobra.Command, inputDir string) error {
+	output, err := scanMetadataJSON(inputDir, metadataUseEmbedded(cmd), metadataFieldMapping(cmd))
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Metadata scan: %s\n", inputDir)
+	fmt.Fprintf(out, "Files scanned: %d\n", output.Summary.FilesScanned)
+	fmt.Fprintf(out, "Errors: %d\n\n", output.Summary.Errors)
+
+	for i, file := range output.Files {
+		if i > 0 {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "Path: %s\n", file.Path)
+		fmt.Fprintf(out, "  Source: %s\n", valueOrDash(file.SourceType))
+		fmt.Fprintf(out, "  Title: %s\n", valueOrDash(file.Title))
+		fmt.Fprintf(out, "  Authors: %s\n", joinedOrDash(file.Authors))
+		fmt.Fprintf(out, "  Series: %s\n", joinedOrDash(file.Series))
+		if file.TrackNumber > 0 {
+			fmt.Fprintf(out, "  Track: %d\n", file.TrackNumber)
+		} else {
+			fmt.Fprintln(out, "  Track: -")
+		}
+		if file.TrackTitle != "" {
+			fmt.Fprintf(out, "  Track Title: %s\n", file.TrackTitle)
+		}
+		fmt.Fprintf(out, "  Album: %s\n", valueOrDash(file.Album))
+		if file.Error != "" {
+			fmt.Fprintf(out, "  Error: %s\n", file.Error)
+		}
+		writeAdditionalMetadataFields(out, file.RawData)
+	}
+
+	return nil
+}
+
+func scanMetadataJSON(
+	inputDir string,
+	useEmbedded bool,
+	fieldMapping organizer.FieldMapping,
+) (metadataJSONOutput, error) {
+	info, err := os.Stat(inputDir)
+	if err != nil {
+		return metadataJSONOutput{}, fmt.Errorf(
+			"error accessing metadata directory %s: %w",
+			inputDir,
+			err,
+		)
+	}
+	if !info.IsDir() {
+		return metadataJSONOutput{}, fmt.Errorf("%s is not a directory", inputDir)
+	}
+
+	output := metadataJSONOutput{
+		Files: []metadataJSONFile{},
+	}
+
+	err = filepath.Walk(inputDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !organizer.IsSupportedFile(filepath.Ext(path)) {
+			return nil
+		}
+
+		output.Summary.FilesScanned++
+		file := metadataJSONFile{
+			Path:       path,
+			SourceType: metadataSourceTypeForPath(path),
+			Authors:    []string{},
+			Series:     []string{},
+		}
+
+		provider := organizer.NewMetadataProvider(path, useEmbedded)
+		metadata, err := provider.GetMetadata()
+		if err != nil {
+			file.Error = fmt.Sprintf("failed to extract metadata: %v", err)
+			output.Summary.Errors++
+			output.Files = append(output.Files, file)
+			return nil
+		}
+
+		if !fieldMapping.IsEmpty() {
+			metadata.ApplyFieldMapping(fieldMapping)
+		}
+
+		file.SourceType = metadata.SourceType
+		file.Title = metadata.Title
+		file.Authors = nonNilStrings(metadata.Authors)
+		file.Series = nonNilStrings(metadata.Series)
+		file.TrackNumber = metadata.TrackNumber
+		file.TrackTitle = metadata.TrackTitle
+		file.Album = metadata.Album
+		file.RawData = metadata.RawData
+		output.Files = append(output.Files, file)
+		return nil
+	})
+	if err != nil {
+		return metadataJSONOutput{}, fmt.Errorf(
+			"error scanning metadata directory %s: %w",
+			inputDir,
+			err,
+		)
+	}
+
+	return output, nil
+}
+
+func metadataInputDir(cmd *cobra.Command) string {
+	inputDir, _ := cmd.Flags().GetString("dir")
+	if inputDir == "" {
+		inputDir, _ = cmd.Flags().GetString("input")
+	}
+	if inputDir == "" {
+		inputDir = viper.GetString("dir")
+	}
+	if inputDir == "" {
+		inputDir = viper.GetString("input")
+	}
+	return inputDir
+}
+
+func errMetadataDirRequired() error {
+	return fmt.Errorf("--dir must be specified")
+}
+
+func syncMetadataFlagsToViper(cmd *cobra.Command, inputDir string) {
+	viper.Set("dir", inputDir)
+
+	useEmbedded, _ := cmd.Flags().GetBool("use-embedded-metadata")
+	flat, _ := cmd.Flags().GetBool("flat")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	viper.Set("use-embedded-metadata", useEmbedded)
+	viper.Set("flat", flat)
+	viper.Set("verbose", verbose)
+
+	if titleField, _ := cmd.Flags().GetString("title-field"); titleField != "" {
+		viper.Set("title-field", titleField)
+	}
+	if seriesField, _ := cmd.Flags().GetString("series-field"); seriesField != "" {
+		viper.Set("series-field", seriesField)
+	}
+	if authorFields, _ := cmd.Flags().GetString("author-fields"); authorFields != "" {
+		viper.Set("author-fields", authorFields)
+	}
+	if trackField, _ := cmd.Flags().GetString("track-field"); trackField != "" {
+		viper.Set("track-field", trackField)
+	}
+}
+
+func metadataUseEmbedded(cmd *cobra.Command) bool {
+	useEmbedded, _ := cmd.Flags().GetBool("use-embedded-metadata")
+	flat, _ := cmd.Flags().GetBool("flat")
+	return useEmbedded || flat
+}
+
+func metadataFieldMapping(cmd *cobra.Command) organizer.FieldMapping {
+	authorFields := []string{}
+	if rawAuthorFields, _ := cmd.Flags().GetString("author-fields"); rawAuthorFields != "" {
+		for _, field := range strings.Split(rawAuthorFields, ",") {
+			trimmed := strings.TrimSpace(field)
+			if trimmed != "" {
+				authorFields = append(authorFields, trimmed)
+			}
+		}
+	}
+
+	titleField, _ := cmd.Flags().GetString("title-field")
+	seriesField, _ := cmd.Flags().GetString("series-field")
+	trackField, _ := cmd.Flags().GetString("track-field")
+
+	return organizer.FieldMapping{
+		TitleField:   titleField,
+		SeriesField:  seriesField,
+		AuthorFields: authorFields,
+		TrackField:   trackField,
+	}
+}
+
+func metadataSourceTypeForPath(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".epub":
+		return "epub"
+	case ".mp3", ".m4b", ".m4a", ".ogg", ".flac":
+		return "audio"
+	default:
+		return "unknown"
+	}
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}
+
+func joinedOrDash(values []string) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	return strings.Join(values, ", ")
+}
+
+func valueOrDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func writeAdditionalMetadataFields(out io.Writer, rawData map[string]interface{}) {
+	fields := additionalMetadataFields(rawData)
+	if len(fields) == 0 {
+		return
+	}
+
+	fmt.Fprintln(out, "  Additional Fields:")
+	for _, field := range fields {
+		fmt.Fprintf(out, "    %s: %s\n", field.key, formatMetadataValue(field.value))
+	}
+}
+
+type metadataField struct {
+	key   string
+	value interface{}
+}
+
+func additionalMetadataFields(rawData map[string]interface{}) []metadataField {
+	if len(rawData) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(rawData))
+	for key, value := range rawData {
+		if skipAdditionalMetadataField(key, value) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	fields := make([]metadataField, 0, len(keys))
+	for _, key := range keys {
+		fields = append(fields, metadataField{key: key, value: rawData[key]})
+	}
+	return fields
+}
+
+func skipAdditionalMetadataField(key string, value interface{}) bool {
+	if value == nil {
+		return true
+	}
+	if strings.HasPrefix(key, "_") {
+		return true
+	}
+	if str, ok := value.(string); ok && strings.TrimSpace(str) == "" {
+		return true
+	}
+	if isZeroMetadataNumber(value) {
+		return true
+	}
+	if values, ok := value.([]string); ok && len(values) == 0 {
+		return true
+	}
+	if values, ok := value.([]interface{}); ok && len(values) == 0 {
+		return true
+	}
+
+	switch key {
+	case "album", "artist", "authors", "series", "title", "track", "track_number", "track_title":
+		return true
+	case "discnumber":
+		return true
+	}
+	return false
+}
+
+func isZeroMetadataNumber(value interface{}) bool {
+	switch v := value.(type) {
+	case int:
+		return v == 0
+	case int8:
+		return v == 0
+	case int16:
+		return v == 0
+	case int32:
+		return v == 0
+	case int64:
+		return v == 0
+	case uint:
+		return v == 0
+	case uint8:
+		return v == 0
+	case uint16:
+		return v == 0
+	case uint32:
+		return v == 0
+	case uint64:
+		return v == 0
+	case float32:
+		return v == 0
+	case float64:
+		return v == 0
+	default:
+		return false
+	}
+}
+
+func formatMetadataValue(value interface{}) string {
+	switch v := value.(type) {
+	case []string:
+		return truncateMetadataValue(strings.Join(v, ", "))
+	case []interface{}:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			parts = append(parts, fmt.Sprintf("%v", item))
+		}
+		return truncateMetadataValue(strings.Join(parts, ", "))
+	default:
+		return truncateMetadataValue(fmt.Sprintf("%v", value))
+	}
+}
+
+func truncateMetadataValue(value string) string {
+	const maxLen = 120
+	if len(value) <= maxLen {
+		return value
+	}
+	return value[:maxLen-3] + "..."
 }

--- a/cmd/metadata_test.go
+++ b/cmd/metadata_test.go
@@ -1,0 +1,336 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jeeftor/audiobook-organizer/internal/organizer"
+	"github.com/spf13/cobra"
+)
+
+func TestMetadataCmd_HasJSONFlag(t *testing.T) {
+	if metadataCmd == nil {
+		t.Fatal("metadataCmd is nil")
+	}
+
+	if metadataCmd.Use != "metadata" {
+		t.Errorf("metadataCmd.Use = %q, want %q", metadataCmd.Use, "metadata")
+	}
+
+	if flag := metadataCmd.Flags().Lookup("json"); flag == nil {
+		t.Fatal("metadataCmd missing json flag")
+	}
+}
+
+func TestMetadataTuiCmd_Registered(t *testing.T) {
+	if metadataTuiCmd == nil {
+		t.Fatal("metadataTuiCmd is nil")
+	}
+
+	if metadataTuiCmd.Use != "metadata-tui" {
+		t.Errorf("metadataTuiCmd.Use = %q, want %q", metadataTuiCmd.Use, "metadata-tui")
+	}
+
+	found := false
+	for _, command := range rootCmd.Commands() {
+		if command.Use == "metadata-tui" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("metadata-tui command is not registered")
+	}
+}
+
+func TestShouldPrintStartupBanner_MetadataJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "metadata suppresses banner",
+			args: []string{"metadata", "--dir", "testdata/mp3flat"},
+			want: false,
+		},
+		{
+			name: "metadata json true suppresses banner",
+			args: []string{"metadata", "--json=true"},
+			want: false,
+		},
+		{
+			name: "metadata json false suppresses banner",
+			args: []string{"metadata", "--json=false"},
+			want: false,
+		},
+		{
+			name: "metadata json zero suppresses banner",
+			args: []string{"metadata", "--json=0"},
+			want: false,
+		},
+		{
+			name: "metadata tui prints banner",
+			args: []string{"metadata-tui", "--dir", "testdata/mp3flat"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldPrintStartupBanner(tt.args); got != tt.want {
+				t.Errorf("shouldPrintStartupBanner(%v) = %t, want %t", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanMetadataJSON_WithMP3FlatFixture(t *testing.T) {
+	output, err := scanMetadataJSON(
+		filepath.Join("..", "testdata", "mp3flat"),
+		true,
+		organizer.FieldMapping{},
+	)
+	if err != nil {
+		t.Fatalf("scanMetadataJSON() error = %v", err)
+	}
+
+	if output.Summary.FilesScanned == 0 {
+		t.Fatal("scanMetadataJSON() scanned no files")
+	}
+	if len(output.Files) != output.Summary.FilesScanned {
+		t.Fatalf(
+			"scanMetadataJSON() files = %d, want %d",
+			len(output.Files),
+			output.Summary.FilesScanned,
+		)
+	}
+
+	first := output.Files[0]
+	if first.Path == "" {
+		t.Fatal("first metadata result missing path")
+	}
+	if first.SourceType == "" {
+		t.Fatal("first metadata result missing source_type")
+	}
+	if first.Authors == nil {
+		t.Fatal("first metadata result authors should be an empty array or populated array")
+	}
+	if first.Series == nil {
+		t.Fatal("first metadata result series should be an empty array or populated array")
+	}
+}
+
+func TestRunMetadataJSON_WritesParseableJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	fixturePath := filepath.Join(
+		"..",
+		"testdata",
+		"mp3flat",
+		"charlesdexterward_01_lovecraft_64kb.mp3",
+	)
+	fixtureBytes, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("failed to read MP3 fixture %s: %v", fixturePath, err)
+	}
+	audioPath := filepath.Join(tmpDir, "book.mp3")
+	if err := os.WriteFile(audioPath, fixtureBytes, 0o644); err != nil {
+		t.Fatalf("failed to write test audio file: %v", err)
+	}
+	metadataPath := filepath.Join(tmpDir, "metadata.json")
+	metadataContent := `{
+		"title": "The JSON Book",
+		"authors": ["Example Author"],
+		"series": ["Example Series"],
+		"track_number": 7,
+		"publishedYear": 2024,
+		"narrator": "Example Narrator"
+	}`
+	if err := os.WriteFile(metadataPath, []byte(metadataContent), 0o644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	cmd := newMetadataJSONTestCommand(t)
+	cmd.Flags().Set("dir", tmpDir)
+	cmd.Flags().Set("json", "true")
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if err := runMetadataJSON(cmd, tmpDir); err != nil {
+		t.Fatalf("runMetadataJSON() error = %v", err)
+	}
+
+	var output metadataJSONOutput
+	if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+		t.Fatalf("metadata JSON did not parse: %v\n%s", err, buf.String())
+	}
+
+	if output.Summary.FilesScanned != 1 {
+		t.Fatalf("files_scanned = %d, want 1", output.Summary.FilesScanned)
+	}
+	if len(output.Files) != 1 {
+		t.Fatalf("files length = %d, want 1", len(output.Files))
+	}
+
+	file := output.Files[0]
+	if file.Path != audioPath {
+		t.Errorf("path = %q, want %q", file.Path, audioPath)
+	}
+	if file.SourceType != "json" {
+		t.Errorf("source_type = %q, want %q", file.SourceType, "json")
+	}
+	if file.Title != "The JSON Book" {
+		t.Errorf("title = %q, want %q", file.Title, "The JSON Book")
+	}
+	if len(file.Authors) != 1 || file.Authors[0] != "Example Author" {
+		t.Errorf("authors = %v, want [Example Author]", file.Authors)
+	}
+	if len(file.Series) != 1 || file.Series[0] != "Example Series" {
+		t.Errorf("series = %v, want [Example Series]", file.Series)
+	}
+	if file.TrackNumber != 1 {
+		t.Errorf("track_number = %d, want 1", file.TrackNumber)
+	}
+	if got := file.RawData["publishedYear"]; got != float64(2024) {
+		t.Errorf("raw_data[publishedYear] = %v, want 2024", got)
+	}
+	if got := file.RawData["narrator"]; got != "Example Narrator" {
+		t.Errorf("raw_data[narrator] = %v, want Example Narrator", got)
+	}
+}
+
+func TestRunMetadataText_WritesTerminalOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	fixturePath := filepath.Join(
+		"..",
+		"testdata",
+		"mp3flat",
+		"charlesdexterward_01_lovecraft_64kb.mp3",
+	)
+	fixtureBytes, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("failed to read MP3 fixture %s: %v", fixturePath, err)
+	}
+	audioPath := filepath.Join(tmpDir, "book.mp3")
+	if err := os.WriteFile(audioPath, fixtureBytes, 0o644); err != nil {
+		t.Fatalf("failed to write test audio file: %v", err)
+	}
+	metadataPath := filepath.Join(tmpDir, "metadata.json")
+	metadataContent := `{
+		"title": "The Text Book",
+		"authors": ["Example Author"],
+		"series": ["Example Series"],
+		"publishedYear": 2024,
+		"narrator": "Example Narrator"
+	}`
+	if err := os.WriteFile(metadataPath, []byte(metadataContent), 0o644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	cmd := newMetadataJSONTestCommand(t)
+	cmd.Flags().Set("dir", tmpDir)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if err := runMetadataText(cmd, tmpDir); err != nil {
+		t.Fatalf("runMetadataText() error = %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Metadata scan: "+tmpDir) {
+		t.Fatalf("terminal output missing scan header:\n%s", output)
+	}
+	if !strings.Contains(output, "Files scanned: 1") {
+		t.Fatalf("terminal output missing file count:\n%s", output)
+	}
+	if !strings.Contains(output, "Path: "+audioPath) {
+		t.Fatalf("terminal output missing file path:\n%s", output)
+	}
+	if !strings.Contains(output, "Source: json") {
+		t.Fatalf("terminal output missing source type:\n%s", output)
+	}
+	if !strings.Contains(output, "Additional Fields:") {
+		t.Fatalf("terminal output missing additional fields section:\n%s", output)
+	}
+	if !strings.Contains(output, "narrator: Example Narrator") {
+		t.Fatalf("terminal output missing additional narrator field:\n%s", output)
+	}
+	if !strings.Contains(output, "publishedYear: 2024") {
+		t.Fatalf("terminal output missing additional publishedYear field:\n%s", output)
+	}
+}
+
+func TestScanMetadataJSON_ReportsExtractionErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	audioPath := filepath.Join(tmpDir, "broken.mp3")
+	if err := os.WriteFile(audioPath, []byte("not real audio"), 0o644); err != nil {
+		t.Fatalf("failed to write test audio file: %v", err)
+	}
+
+	output, err := scanMetadataJSON(tmpDir, true, organizer.FieldMapping{})
+	if err != nil {
+		t.Fatalf("scanMetadataJSON() error = %v", err)
+	}
+
+	if output.Summary.FilesScanned != 1 {
+		t.Fatalf("files_scanned = %d, want 1", output.Summary.FilesScanned)
+	}
+	if output.Summary.Errors != 1 {
+		t.Fatalf("errors = %d, want 1", output.Summary.Errors)
+	}
+	if len(output.Files) != 1 {
+		t.Fatalf("files length = %d, want 1", len(output.Files))
+	}
+	if output.Files[0].Path != audioPath {
+		t.Errorf("path = %q, want %q", output.Files[0].Path, audioPath)
+	}
+	if output.Files[0].Error == "" {
+		t.Fatal("expected extraction error in JSON output")
+	}
+}
+
+func TestAdditionalMetadataFields_FiltersEmptyCoreAndZeroValues(t *testing.T) {
+	fields := additionalMetadataFields(map[string]interface{}{
+		"title":       "Core Title",
+		"authors":     []string{"Core Author"},
+		"_source":     "internal marker",
+		"empty":       "",
+		"empty_list":  []string{},
+		"year":        0,
+		"disc":        0,
+		"track_total": 0,
+		"genre":       "speech",
+		"identifier":  "id-123",
+	})
+
+	got := make([]string, 0, len(fields))
+	for _, field := range fields {
+		got = append(got, field.key)
+	}
+
+	want := []string{"genre", "identifier"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("additional fields = %v, want %v", got, want)
+	}
+}
+
+func newMetadataJSONTestCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "metadata-test"}
+	cmd.Flags().StringP("dir", "d", "", "Directory to scan for audiobooks")
+	cmd.Flags().String("input", "", "Alias for --dir")
+	cmd.Flags().Bool("use-embedded-metadata", false, "Force use of embedded metadata")
+	cmd.Flags().Bool("flat", false, "Flat mode")
+	cmd.Flags().Bool("json", false, "Write metadata scan results as JSON")
+	cmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+	cmd.Flags().String("title-field", "", "Field to use for title")
+	cmd.Flags().String("series-field", "", "Field to use for series")
+	cmd.Flags().String("author-fields", "", "Comma-separated fields for authors")
+	cmd.Flags().String("track-field", "", "Field to use for track number")
+	return cmd
+}

--- a/cmd/metadata_tui.go
+++ b/cmd/metadata_tui.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"github.com/jeeftor/audiobook-organizer/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+// metadataTuiCmd represents the metadata-tui command for interactive metadata exploration.
+var metadataTuiCmd = &cobra.Command{
+	Use:   "metadata-tui",
+	Short: "Start the Terminal User Interface (TUI) for metadata exploration",
+	Long: `Launch a Terminal User Interface (TUI) for exploring audiobook metadata.
+
+This interactive mode allows you to:
+- Scan directories for audiobook files
+- Preview metadata fields from both metadata.json and embedded sources
+- Configure field mappings interactively
+- Build and test rename templates
+- Inspect the metadata available before organizing or renaming files`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if metadataInputDir(cmd) == "" {
+			return errMetadataDirRequired()
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		inputDir := metadataInputDir(cmd)
+		syncMetadataFlagsToViper(cmd, inputDir)
+		return tui.RunRenameMode(inputDir)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(metadataTuiCmd)
+
+	metadataTuiCmd.Flags().StringP("dir", "d", "", "Directory to scan for audiobooks")
+	metadataTuiCmd.Flags().String("input", "", "Alias for --dir")
+	metadataTuiCmd.Flags().
+		Bool("use-embedded-metadata", false, "Force use of embedded metadata (ignore metadata.json)")
+	metadataTuiCmd.Flags().Bool("flat", false, "Flat mode (implies --use-embedded-metadata)")
+	metadataTuiCmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+	metadataTuiCmd.Flags().
+		String("title-field", "", "Field to use for title (e.g., 'title', 'album')")
+	metadataTuiCmd.Flags().
+		String("series-field", "", "Field to use for series (e.g., 'series', 'album')")
+	metadataTuiCmd.Flags().
+		String("author-fields", "", "Comma-separated fields for authors (e.g., 'artist,album_artist')")
+	metadataTuiCmd.Flags().
+		String("track-field", "", "Field to use for track number (e.g., 'track', 'track_number')")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -194,9 +194,20 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() error {
-	color.Cyan("🎧 Audiobook Organizer")
-	color.Cyan("=====================")
+	if shouldPrintStartupBanner(os.Args[1:]) {
+		color.Cyan("🎧 Audiobook Organizer")
+		color.Cyan("=====================")
+	}
 	return rootCmd.Execute()
+}
+
+func shouldPrintStartupBanner(args []string) bool {
+	for _, arg := range args {
+		if arg == "metadata" {
+			return false
+		}
+	}
+	return true
 }
 
 // getEnvValue checks all possible environment variable names for a config key

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -924,7 +924,7 @@ audiobook-organizer abs scan \
 **Solutions:**
 - Use `--skip-errors` with `--flat` to skip files with bad metadata and organize the rest
 - Use `--author-fields` to specify correct metadata fields
-- Check file tags with metadata viewer: `audiobook-organizer metadata --dir=/path`
+- Check file tags with metadata viewer: `audiobook-organizer metadata-tui --dir=/path`
 - Verify audio files aren't corrupted
 - See [METADATA.md](METADATA.md) for field mapping guide
 
@@ -949,7 +949,7 @@ audiobook-organizer abs scan \
 ### Dry run shows unexpected results
 
 **Solutions:**
-- Review field mapping: use `audiobook-organizer metadata --dir=/path`
+- Review field mapping: use `audiobook-organizer metadata-tui --dir=/path`
 - Adjust `--layout` option
 - Check `--author-fields`, `--title-field`, `--series-field` values
 - Use `--verbose` for detailed logging

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -10,6 +10,8 @@ Audiobook Organizer ships as one binary named `audiobook-organizer`. The same bi
 | `audiobook-organizer gui` | Local Web UI alias | Compatibility alias for `web` |
 | `audiobook-organizer tui` | Interactive Terminal | Keyboard-driven terminal workflow |
 | `audiobook-organizer rename-tui` | Rename TUI | Interactive rename workflow |
+| `audiobook-organizer metadata` | Metadata CLI | Text-only metadata inspection |
+| `audiobook-organizer metadata-tui` | Metadata TUI | Interactive metadata exploration |
 | `audiobook-organizer abs` | Audiobookshelf CLI | ABS libraries, mappings, item loading, and scan triggers |
 | `audiobook-organizer --dir=/path` | CLI | Scriptable organization |
 

--- a/docs/LAYOUTS.md
+++ b/docs/LAYOUTS.md
@@ -567,7 +567,7 @@ Internal layout patterns map to path construction:
 1. Use `--dry-run` to preview before executing
 2. Check metadata extraction with metadata viewer:
    ```bash
-   audiobook-organizer metadata --dir=/path
+   audiobook-organizer metadata-tui --dir=/path
    ```
 3. Verify author, series, title fields are populated
 4. Consider field mapping if using embedded metadata

--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -507,7 +507,7 @@ Output:
 Use the metadata viewer to explore extracted fields:
 
 ```bash
-audiobook-organizer metadata --dir=/path/to/audiobooks
+audiobook-organizer metadata-tui --dir=/path/to/audiobooks
 ```
 
 **Shows:**
@@ -533,7 +533,7 @@ audiobook-organizer metadata --dir=/path/to/audiobooks
 **Solutions:**
 1. Verify files contain metadata:
    ```bash
-   audiobook-organizer metadata --dir=/path
+   audiobook-organizer metadata --dir=/path --json
    ```
 2. Check file formats are supported (EPUB, MP3, M4B, metadata.json)
 3. Try `--use-embedded-metadata` if no metadata.json files
@@ -546,7 +546,7 @@ audiobook-organizer metadata --dir=/path/to/audiobooks
 **Solutions:**
 1. Use metadata viewer to see available fields:
    ```bash
-   audiobook-organizer metadata --dir=/path
+   audiobook-organizer metadata-tui --dir=/path
    ```
 2. Configure field mapping:
    ```bash
@@ -569,7 +569,7 @@ audiobook-organizer metadata --dir=/path/to/audiobooks
 **Solutions:**
 1. Verify metadata consistency:
    ```bash
-   audiobook-organizer metadata --dir=/path
+   audiobook-organizer metadata-tui --dir=/path
    ```
 2. Use non-flat mode (default) for multi-file books
 3. Edit file tags to ensure consistent metadata
@@ -582,7 +582,7 @@ audiobook-organizer metadata --dir=/path/to/audiobooks
 **Solutions:**
 1. Check track field:
    ```bash
-   audiobook-organizer metadata --dir=/path
+   audiobook-organizer metadata-tui --dir=/path
    ```
 2. Configure track field:
    ```bash
@@ -622,7 +622,7 @@ audiobook-organizer --dir=/path --dry-run --verbose
 Before organizing, explore metadata:
 
 ```bash
-audiobook-organizer metadata --dir=/path
+audiobook-organizer metadata-tui --dir=/path
 ```
 
 ### 3. Test Field Mapping
@@ -681,6 +681,6 @@ title-field: "album"
 
 When reporting metadata issues, please include:
 - File format (MP3, M4B, EPUB, metadata.json)
-- Output of `audiobook-organizer metadata --dir=/path`
+- Output of `audiobook-organizer metadata --dir=/path --json`
 - Expected vs actual metadata
 - Sample file (if possible)

--- a/docs/METADATA_COMMAND.md
+++ b/docs/METADATA_COMMAND.md
@@ -2,12 +2,14 @@
 
 ## Overview
 
-The `metadata` command provides an interactive TUI for exploring audiobook metadata. It helps you understand what metadata is available in your files before organizing or renaming them.
+The `metadata` command inspects audiobook metadata non-interactively and writes text-only output to the terminal. Add `--json` when scripts, tests, or CI need machine-readable output.
+
+Use `metadata-tui` when you want the interactive terminal workflow for exploring fields, mappings, and rename templates before organizing or renaming files.
 
 ## Usage
 
 ```bash
-# Basic usage
+# Text-only output
 audiobook-organizer metadata --dir=/path/to/audiobooks
 
 # Short form
@@ -19,13 +21,51 @@ audiobook-organizer metadata --dir=/path --use-embedded-metadata
 # Flat mode
 audiobook-organizer metadata --dir=/path --flat
 
-# Verbose output
-audiobook-organizer metadata --dir=/path -v
+# Machine-readable JSON output
+audiobook-organizer metadata --dir=/path --json
+
+# Interactive metadata exploration
+audiobook-organizer metadata-tui --dir=/path/to/audiobooks
 ```
 
-## Features
+## Text Output
 
-The metadata command provides an interactive interface with multiple screens:
+`metadata` recursively scans supported files and prints a text-only summary plus one block per file.
+
+Each file block includes:
+
+- path
+- source type
+- title
+- authors
+- series
+- track number
+- album
+- extraction error, when extraction fails for that file
+- additional metadata fields, when the metadata source exposes fields beyond the core display
+
+## JSON Output
+
+`metadata --json` recursively scans supported files and writes a JSON object with `files` and `summary` fields.
+
+Each file record includes:
+
+- `path`
+- `source_type`
+- `title`
+- `authors`
+- `series`
+- `track_number`
+- `track_title`
+- `album`
+- `raw_data`, when the source exposes additional metadata fields
+- `error`, when extraction fails for that file
+
+Per-file extraction errors are included in the JSON output. Command-level failures, such as a missing input directory, return a non-zero exit code.
+
+## Interactive Features
+
+The `metadata-tui` command provides an interactive interface with multiple screens:
 
 ### 1. Scan Screen
 - Automatically scans the directory for audiobook files
@@ -139,13 +179,13 @@ By default, the command prefers metadata.json if present, falling back to embedd
 
 ### Force Embedded Metadata
 ```bash
-audiobook-organizer metadata --dir=/path --use-embedded-metadata
+audiobook-organizer metadata-tui --dir=/path --use-embedded-metadata
 ```
 Ignores metadata.json files and always uses embedded tags from each file.
 
 ### Flat Mode
 ```bash
-audiobook-organizer metadata --dir=/path --flat
+audiobook-organizer metadata-tui --dir=/path --flat
 ```
 Implies `--use-embedded-metadata`. Useful for flat directory structures.
 
@@ -176,7 +216,7 @@ Implies `--use-embedded-metadata`. Useful for flat directory structures.
 Use the metadata command to see what fields are available in your files before deciding on an organization or rename strategy:
 
 ```bash
-audiobook-organizer metadata --dir=/path/to/books
+audiobook-organizer metadata-tui --dir=/path/to/books
 ```
 
 Press F2 to see actual metadata from your files.
@@ -185,7 +225,7 @@ Press F2 to see actual metadata from your files.
 Build and test rename templates interactively:
 
 ```bash
-audiobook-organizer metadata --dir=/path/to/books
+audiobook-organizer metadata-tui --dir=/path/to/books
 ```
 
 Type different templates and see live previews of how files would be renamed.
@@ -195,16 +235,16 @@ See the difference between metadata.json and embedded metadata:
 
 ```bash
 # View metadata.json data
-audiobook-organizer metadata --dir=/path/to/books
+audiobook-organizer metadata-tui --dir=/path/to/books
 
 # View embedded metadata
-audiobook-organizer metadata --dir=/path/to/books --use-embedded-metadata
+audiobook-organizer metadata-tui --dir=/path/to/books --use-embedded-metadata
 ```
 
 Press F2 to see which source is being used.
 
 ### 4. Interactive Rename Workflow
-The metadata command doubles as an interactive rename tool:
+The `metadata-tui` command doubles as an interactive rename tool:
 
 1. Scan files
 2. Build template with live preview
@@ -216,7 +256,7 @@ The metadata command doubles as an interactive rename tool:
 
 ### Example 1: Explore Metadata
 ```bash
-audiobook-organizer metadata --dir=./audiobooks
+audiobook-organizer metadata-tui --dir=./audiobooks
 ```
 
 1. Scans the directory
@@ -227,7 +267,7 @@ audiobook-organizer metadata --dir=./audiobooks
 
 ### Example 2: Test Different Templates
 ```bash
-audiobook-organizer metadata --dir=./audiobooks
+audiobook-organizer metadata-tui --dir=./audiobooks
 ```
 
 Try different templates:
@@ -239,7 +279,7 @@ See live preview for each template.
 
 ### Example 3: Rename with Preview
 ```bash
-audiobook-organizer metadata --dir=./audiobooks
+audiobook-organizer metadata-tui --dir=./audiobooks
 ```
 
 1. Build your template
@@ -249,12 +289,16 @@ audiobook-organizer metadata --dir=./audiobooks
 
 ## Comparison with Other Commands
 
-### `metadata` vs `rename`
-- **metadata**: Interactive TUI with live preview and metadata display
+### `metadata` vs `metadata-tui`
+- **metadata**: Text-only metadata inspection, with `--json` for machine-readable output
+- **metadata-tui**: Interactive TUI with live preview and metadata display
+
+### `metadata-tui` vs `rename`
+- **metadata-tui**: Interactive exploration and template preview
 - **rename**: Non-interactive CLI for batch operations
 
 ### `metadata` vs `gui`
-- **metadata**: Focused on metadata exploration and renaming
+- **metadata**: Focused on terminal metadata inspection
 - **gui**: Full organization workflow (scan → organize → move files)
 
 ## Tips

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -394,7 +394,7 @@ The **Metadata Viewer** lets you explore metadata for audiobook files interactiv
 
 ```bash
 # Interactive metadata exploration
-audiobook-organizer metadata --dir=/path/to/audiobooks
+audiobook-organizer metadata-tui --dir=/path/to/audiobooks
 ```
 
 ### Features


### PR DESCRIPTION
Resolves #34

## Summary

- Splits metadata inspection into non-interactive `metadata` output and interactive `metadata-tui`.
- Adds `metadata --json` with per-file summary data and full `raw_data` for scripting.
- Prints plain text metadata with core fields plus sorted additional fields when present.
- Updates CLI/docs/changelog references for the new command split.

## Tests

- `go test ./cmd -run 'TestMetadata|TestRunMetadata|TestScanMetadata|TestAdditionalMetadata|TestShouldPrintStartupBanner'`
- `make fmt-check`
- `make test-unit`
- `prek run --all-files`

## Docs and Changelog

- Updated `README.md`, CLI/TUI/metadata docs, and installation/layout references.
- Added an `Unreleased` changelog entry.

## Follow-up

- None identified.
