### PR TITLE
Remediate SonarCloud quality gate failures

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'develop'
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Build on each platform
@@ -58,6 +58,8 @@ jobs:
   pre-release:
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - 'v*'
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   debug:
@@ -105,6 +105,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -220,10 +220,7 @@ func (s *Server) handleABSScanTrigger(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/")
-	if path == "" {
-		path = "index.html"
-	}
+	path := staticAssetPath(r.URL.Path)
 	if _, err := fs.Stat(s.static, path); err != nil {
 		path = "index.html"
 	}
@@ -264,6 +261,14 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Cache-Control", "no-store, max-age=0")
 	http.ServeContent(w, r, path, stat.ModTime(), bytes.NewReader(data))
+}
+
+func staticAssetPath(requestPath string) string {
+	path := strings.TrimPrefix(requestPath, "/")
+	if path == "" || path == "." || !fs.ValidPath(path) || strings.Contains(path, `\`) {
+		return "index.html"
+	}
+	return path
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, target any) bool {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -122,6 +122,48 @@ func TestStaticRoutesServeIndexAndSPAFallback(t *testing.T) {
 	}
 }
 
+func TestStaticAssetPathRejectsTraversal(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "root", path: "/", want: "index.html"},
+		{name: "asset", path: "/assets/index.js", want: "assets/index.js"},
+		{
+			name: "spa route",
+			path: "/library/not-a-real-static-file",
+			want: "library/not-a-real-static-file",
+		},
+		{name: "parent traversal", path: "/../secret", want: "index.html"},
+		{name: "nested parent traversal", path: "/assets/../../secret", want: "index.html"},
+		{name: "current directory segment", path: "/assets/./index.js", want: "index.html"},
+		{name: "windows separator", path: `/assets\..\secret`, want: "index.html"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := staticAssetPath(tt.path)
+			if got != tt.want {
+				t.Fatalf("staticAssetPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStaticRoutesFallBackForTraversalRequests(t *testing.T) {
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/%2e%2e/secret", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStatic(rec, req)
+
+	assertStatus(t, rec, http.StatusOK)
+	if !strings.Contains(rec.Body.String(), `<div id="app"></div>`) {
+		t.Fatalf("expected embedded app shell, got body:\n%s", rec.Body.String())
+	}
+}
+
 func TestPostEndpointsRejectWrongMethodAndInvalidJSON(t *testing.T) {
 	handler := newTestHandler(t)
 
@@ -312,6 +354,12 @@ func TestABSEndpointsReturnValidationErrorsBeforeDockerIsNeeded(t *testing.T) {
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 
+	return newTestServer(t).routes()
+}
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+
 	cfg := app.DefaultWebConfig("127.0.0.1", 0, false, "/input", "/output")
 	cfg.ABS = app.ABSConfigDTO{
 		URL:       "http://abs.local",
@@ -326,7 +374,7 @@ func newTestHandler(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatalf("new server: %v", err)
 	}
-	return srv.routes()
+	return srv
 }
 
 func performRequest(

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.test.exclusions=
 
 # Configure source code analysis
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/vendor/**,**/testdata/**,**/example/**,**/*.pb.go
+sonar.exclusions=**/*_test.go,**/vendor/**,**/test/**,**/tests/**,**/testdata/**,**/example/**,**/internal/server/static/**,**/*.pb.go
 
 # Set Go specific properties
 sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
Resolves #51

## Summary

- Harden static asset routing so invalid, backslash, or traversal-like request paths fall back to the embedded SPA shell before opening embedded files.
- Add server regression coverage for traversal-like static requests and legitimate static/SPA route paths.
- Move release workflow `contents: write` permissions from workflow scope to only the release/pre-release jobs.
- Exclude test harness paths and generated embedded static assets from Sonar production source analysis.

## Tests

- `go test ./internal/server`
- `go test ./...`
- `git diff --check`
- Commit hooks: trailing whitespace, EOF, YAML, large file, merge conflict, private key, mixed line ending, goimports, gofumpt, golines, conventional commit

## Docs, Changelog, ABS

- Docs: not changed; this is CI/security hygiene.
- Changelog: not updated; no user-facing behavior change.
- ABS matrix: not applicable; no ABS-facing behavior change.

## Notes

- Local `actionlint` is not installed, so workflow validation is limited to YAML hook checks and the upcoming GitHub Actions run.
- SonarCloud must run on this PR to confirm the quality gate clears. Any remaining manual hotspots after that run should be reviewed in SonarCloud or split into follow-up remediation.
