### PR TITLE
Fix beta release tag generation

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -93,18 +93,12 @@ jobs:
       - name: List dist contents
         run: ls -R dist/
 
-      # Generate version for pre-release
+      # Generate version for pre-release.
+      # Beta tags are based on the latest stable vMAJOR.MINOR.PATCH tag;
+      # existing prerelease tags are ignored to avoid nested beta suffixes.
       - name: Generate version info
         id: version
-        run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g')
-          VERSION="${LAST_TAG}-beta.${SHORT_SHA}"
-          RELEASE_NAME="${LAST_TAG}-beta (${BRANCH_NAME})"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "release_name=${RELEASE_NAME}" >> $GITHUB_OUTPUT
-          echo "branch=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+        run: sh scripts/beta-version.sh
 
       # Create archives manually (since we're not using goreleaser release)
       - name: Create archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Beta release tags now derive from the latest stable SemVer tag instead of stacking beta suffixes from prior prereleases.
 - Frontend embed path is now stable for goreleaser by building into `internal/server/static`.
 - Release workflows build the web frontend before packaging the single binary.
 

--- a/scripts/beta-version.sh
+++ b/scripts/beta-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+set -eu
+
+latest_stable_tag() {
+	git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname |
+		grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+		head -n 1 || true
+}
+
+base_version="${BETA_BASE_VERSION:-$(latest_stable_tag)}"
+if [ -z "$base_version" ]; then
+	base_version="v0.0.0"
+fi
+
+short_sha="${BETA_SHORT_SHA:-$(git rev-parse --short HEAD)}"
+branch_name="${BETA_BRANCH_NAME:-}"
+if [ -z "$branch_name" ]; then
+	if [ -n "${GITHUB_REF:-}" ]; then
+		branch_name="${GITHUB_REF#refs/heads/}"
+	else
+		branch_name="$(git rev-parse --abbrev-ref HEAD)"
+	fi
+fi
+branch_name="$(printf '%s' "$branch_name" | tr '/' '-')"
+
+version="${base_version}-beta.${short_sha}"
+release_name="${base_version}-beta (${branch_name})"
+
+{
+	printf 'version=%s\n' "$version"
+	printf 'release_name=%s\n' "$release_name"
+	printf 'branch=%s\n' "$branch_name"
+} | tee -a "${GITHUB_OUTPUT:-/dev/null}"

--- a/scripts/beta_version_test.go
+++ b/scripts/beta_version_test.go
@@ -1,0 +1,118 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBetaVersionIgnoresPrereleaseTags(t *testing.T) {
+	repo := newGitRepo(t)
+	git(t, repo, "tag", "v0.11.0")
+	git(t, repo, "tag", "v0.11.0-beta.cd9c813")
+	git(t, repo, "tag", "v0.11.0-beta.cd9c813-beta.707d4f7")
+
+	output := runBetaVersion(t, repo, "707d4f7", "develop")
+
+	assertOutputLine(t, output, "version", "v0.11.0-beta.707d4f7")
+	assertOutputLine(t, output, "release_name", "v0.11.0-beta (develop)")
+	assertOutputLine(t, output, "branch", "develop")
+	if strings.Contains(output["version"], "beta.cd9c813-beta") {
+		t.Fatalf("version contains nested beta suffix: %q", output["version"])
+	}
+}
+
+func TestBetaVersionUsesNewestStableSemverTag(t *testing.T) {
+	repo := newGitRepo(t)
+	git(t, repo, "tag", "v0.9.0")
+	git(t, repo, "tag", "v0.10.0")
+	git(t, repo, "tag", "v0.10.1-beta.old")
+	git(t, repo, "tag", "v0.11.0")
+
+	output := runBetaVersion(t, repo, "abc1234", "release/beta-sync")
+
+	assertOutputLine(t, output, "version", "v0.11.0-beta.abc1234")
+	assertOutputLine(t, output, "release_name", "v0.11.0-beta (release-beta-sync)")
+	assertOutputLine(t, output, "branch", "release-beta-sync")
+}
+
+func TestBetaVersionFallsBackWithoutStableTags(t *testing.T) {
+	repo := newGitRepo(t)
+	git(t, repo, "tag", "v0.1.0-beta.old")
+
+	output := runBetaVersion(t, repo, "abc1234", "develop")
+
+	assertOutputLine(t, output, "version", "v0.0.0-beta.abc1234")
+	assertOutputLine(t, output, "release_name", "v0.0.0-beta (develop)")
+}
+
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.email", "test@example.invalid")
+	git(t, repo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	git(t, repo, "add", "README.md")
+	git(t, repo, "commit", "-m", "initial")
+	return repo
+}
+
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func runBetaVersion(t *testing.T, repo, shortSHA, branchName string) map[string]string {
+	t.Helper()
+
+	script, err := filepath.Abs("beta-version.sh")
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	cmd := exec.Command("sh", script)
+	cmd.Dir = repo
+	cmd.Env = append(
+		os.Environ(),
+		"BETA_SHORT_SHA="+shortSHA,
+		"BETA_BRANCH_NAME="+branchName,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run beta-version.sh: %v\n%s", err, output)
+	}
+	return parseOutput(t, string(output))
+}
+
+func parseOutput(t *testing.T, output string) map[string]string {
+	t.Helper()
+
+	values := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			t.Fatalf("output line %q does not contain key=value", line)
+		}
+		values[key] = value
+	}
+	return values
+}
+
+func assertOutputLine(t *testing.T, output map[string]string, key, want string) {
+	t.Helper()
+
+	if got := output[key]; got != want {
+		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}


### PR DESCRIPTION
Resolves #55

## Summary

- Move beta release version generation into `scripts/beta-version.sh`.
- Derive beta tags from the latest stable `vMAJOR.MINOR.PATCH` tag only, ignoring existing prerelease/beta tags.
- Add focused regression tests for nested beta tags, newest stable tag selection, branch-name sanitization, and no-stable-tag fallback.
- Document the beta tag behavior in the workflow and changelog.

## Tests

- `go test ./scripts`
- `go test ./...`
- `git diff --check`
- `prek run --all-files`
- Commit hooks: trailing whitespace, EOF, YAML, large file, merge conflict, private key, mixed line ending, goimports, gofumpt, golines, conventional commit

## Docs, Changelog, ABS

- Docs: workflow comment documents the stable-tag beta behavior.
- Changelog: added an Unreleased fix entry.
- ABS matrix: not applicable; release workflow only.
