### PR TITLE
Document protected branch workflow

### DIFF
--- a/.agents/skills/abo-issue-closeout/SKILL.md
+++ b/.agents/skills/abo-issue-closeout/SKILL.md
@@ -18,7 +18,7 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 3. Add missing `CHANGELOG.md`, docs, or `test/abs/test-matrix.md` updates when required.
 4. Comment on the issue with what changed, tests run, and any follow-up work.
 5. If a PR will close the issue, ensure the PR body uses `Resolves #<issue>` and do not manually close it.
-6. Treat the issue as open until the resolving PR is ready, required checks pass, required review is satisfied or auto-merge is enabled while review is pending, and the PR has merged back into `master`.
+6. Treat the issue as open until the resolving PR is ready, required checks pass, auto-merge is enabled or the PR has merged back into `master`, and the linked issue has closed.
 7. After merge, confirm the linked issue closed and the feature branch or worktree was cleaned up. Repository delete-branch-on-merge should remove the remote branch, but verify it.
 8. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
 9. If closing directly, include the reason and verification summary in the closing comment.

--- a/.agents/skills/abo-issue-closeout/SKILL.md
+++ b/.agents/skills/abo-issue-closeout/SKILL.md
@@ -18,8 +18,8 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 3. Add missing `CHANGELOG.md`, docs, or `test/abs/test-matrix.md` updates when required.
 4. Comment on the issue with what changed, tests run, and any follow-up work.
 5. If a PR will close the issue, ensure the PR body uses `Resolves #<issue>` and do not manually close it.
-6. Treat the issue as open until the resolving PR is ready, required checks and review are satisfied, and the PR has merged back into `master`.
-7. After merge, confirm the linked issue closed and the feature branch or worktree was cleaned up.
+6. Treat the issue as open until the resolving PR is ready, required checks pass, required review is satisfied or auto-merge is enabled while review is pending, and the PR has merged back into `master`.
+7. After merge, confirm the linked issue closed and the feature branch or worktree was cleaned up. Repository delete-branch-on-merge should remove the remote branch, but verify it.
 8. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
 9. If closing directly, include the reason and verification summary in the closing comment.
 

--- a/.agents/skills/abo-pr-create/SKILL.md
+++ b/.agents/skills/abo-pr-create/SKILL.md
@@ -31,6 +31,6 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 9. Push the branch and set upstream.
 10. Create a PR with `gh pr create --base master --head <branch> --body-file <file>`.
 11. Verify the PR URL, target branch, and initial check/review state before reporting success.
-12. If the PR is intentionally ready for merge, do not leave it as a draft. Protected `master` requires passing checks and one approving review before merge.
+12. If the PR is intentionally ready for merge, do not leave it as a draft. Protected `master` requires passing checks before merge; enable auto-merge when the PR is otherwise ready.
 
 End with the PR URL, tests run, and any checks still pending.

--- a/.agents/skills/abo-pr-create/SKILL.md
+++ b/.agents/skills/abo-pr-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: abo-pr-create
-description: Commit, push, and create Audiobook Organizer pull requests into master after verification and PR body preparation.
+description: Commit, push, and create Audiobook Organizer pull requests into protected master after verification and PR body preparation.
 metadata:
   short-description: Create ABO PRs
 ---
@@ -29,7 +29,8 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 7. Commit with a concise message tied to the issue.
 8. Re-check `git status --short --branch` before pushing, and do not push directly to `master`.
 9. Push the branch and set upstream.
-10. Create a draft PR with `gh pr create --base master --head <branch> --draft --body-file <file>`.
-11. Verify the PR URL and draft state before reporting success.
+10. Create a PR with `gh pr create --base master --head <branch> --body-file <file>`.
+11. Verify the PR URL, target branch, and initial check/review state before reporting success.
+12. If the PR is intentionally ready for merge, do not leave it as a draft. Protected `master` requires passing checks and one approving review before merge.
 
 End with the PR URL, tests run, and any checks still pending.

--- a/.agents/skills/abo-pr-watcher/SKILL.md
+++ b/.agents/skills/abo-pr-watcher/SKILL.md
@@ -20,7 +20,10 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 5. Before applying fixes, confirm `git status --short --branch` shows the PR branch and not `master`.
 6. Apply mechanical or clearly requested fixes; ask before behavior changes or risky rebases.
 7. Run the narrowest relevant checks after fixes.
-8. When checks and review are clean, report whether the PR is ready to merge back into `master` and whether the linked issue will close.
-9. Summarize what changed, what remains blocked, and what should rerun.
+8. When checks are green, inspect `mergeStateStatus` and `reviewDecision`.
+9. If the only blocker is required review and repository auto-merge is available, run `gh pr merge <number> --auto --squash --delete-branch` and report that approval is pending.
+10. When checks and review are clean, report whether the PR is merging or ready to merge back into `master` and whether the linked issue will close.
+11. Summarize what changed, what remains blocked, and what should rerun.
 
 Do not dismiss failures as flaky without evidence.
+Do not bypass protected `master` or admin enforcement for normal work.

--- a/.agents/skills/abo-pr-watcher/SKILL.md
+++ b/.agents/skills/abo-pr-watcher/SKILL.md
@@ -21,8 +21,8 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 6. Apply mechanical or clearly requested fixes; ask before behavior changes or risky rebases.
 7. Run the narrowest relevant checks after fixes.
 8. When checks are green, inspect `mergeStateStatus` and `reviewDecision`.
-9. If the only blocker is required review and repository auto-merge is available, run `gh pr merge <number> --auto --squash --delete-branch` and report that approval is pending.
-10. When checks and review are clean, report whether the PR is merging or ready to merge back into `master` and whether the linked issue will close.
+9. If required checks are green and repository auto-merge is available, run `gh pr merge <number> --auto --squash --delete-branch`. If GitHub reports `REVIEW_REQUIRED`, report that branch protection is out of sync with the single-maintainer workflow.
+10. When checks and merge state are clean, report whether the PR is merging or ready to merge back into `master` and whether the linked issue will close.
 11. Summarize what changed, what remains blocked, and what should rerun.
 
 Do not dismiss failures as flaky without evidence.

--- a/.agents/skills/abo-pr/SKILL.md
+++ b/.agents/skills/abo-pr/SKILL.md
@@ -18,6 +18,6 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 - Existing PR status, comments, checks, or requested changes: `$abo-pr-watcher`.
 - Issue completion checks before PR: `$abo-issue-verify`.
 - Final issue/changelog/docs hygiene: `$abo-issue-closeout`.
-- Finished feature, fix, docs, or chore branch: verify checks, get the PR ready, merge back into `master`, confirm the issue closed, and clean up the branch or worktree.
+- Finished feature, fix, docs, or chore branch: verify checks, get the PR ready, enable auto-merge or merge back into protected `master`, confirm the issue closed, and clean up the branch or worktree.
 
 If intent is unclear, ask whether the user wants PR text, PR creation, PR status watching, or closeout verification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Use these skills for repeatable Audiobook Organizer workflows:
 - `$abo-docs`: maintain docs, AGENTS.md, changelog, and repo-local skill references.
 - `$abo-pr`: route PR drafting, creation, watching, and closeout.
 - `$abo-pr-writer`: draft or update PR descriptions.
-- `$abo-pr-create`: commit, push, and create a draft PR into `master`.
+- `$abo-pr-create`: commit, push, and create a PR into protected `master`.
 - `$abo-pr-watcher`: watch PR CI, review comments, issue comments, and branch freshness.
 
 Shared skill references live in `references/abo-assistant/`. Keep AGENTS.md focused on durable repo rules; put detailed repeatable procedures in the relevant skill or shared reference.
@@ -66,6 +66,7 @@ Shared skill references live in `references/abo-assistant/`. Keep AGENTS.md focu
 - Create a dedicated branch from `master` for each issue before editing files. Start from a fresh remote base with `git fetch origin master` and `git switch -c <branch> origin/master`.
 - Use descriptive branch prefixes by work type: `feature/<short-name>` for features, `fix/<short-name>` for bug fixes, `docs/<short-name>` for documentation-only changes, and `chore/<short-name>` for maintainer/tooling work.
 - Verify the active branch with `git status --short --branch` before editing, committing, or pushing. Do not commit or push from `master` except for explicitly approved tiny edits or explicit repository maintenance such as an approved history rewrite.
+- `master` is protected. Normal work must merge through a pull request with required checks passing and one approving review. Admin enforcement is enabled; do not bypass protection for normal work.
 - Keep the issue updated while working. Add comments for scope changes, important implementation decisions, blockers, test results, and follow-up work discovered during implementation.
 - Keep commits focused on the issue. Do not mix unrelated cleanup, refactors, or separate features into the same branch.
 - As part of each feature or fix, decide whether tests, docs, and `CHANGELOG.md` need updates. If they do, include them in the same branch. If they do not, note why in the PR.
@@ -75,6 +76,7 @@ Shared skill references live in `references/abo-assistant/`. Keep AGENTS.md focu
 - When pre-commit hooks are configured, prefer `prek run --all-files` over `pre-commit run --all-files`. If hooks are installed locally but no config exists on the branch, report that instead of treating hook execution as required.
 - When creating a separate Git worktree, install both pre-commit and commit-message hooks in that worktree when hook config exists, for example `prek install --hook-type pre-commit --hook-type commit-msg`.
 - Open a pull request into `master` when the branch is ready. The PR body must include the issue it resolves, a short summary, tests run, docs/changelog status, and any follow-up issues created.
+- Repository auto-merge is enabled. When checks are green and the only blocker is required review, enable auto-merge with squash merge and delete the branch after merge; then report that human approval is the remaining blocker.
 - Prefer Squash and merge for PRs unless the maintainer asks for another merge strategy.
 - A feature, fix, docs, or chore issue is not complete at local commit or draft PR time. Close the cycle by getting the PR ready, passing required checks, merging back into `master`, and letting the linked issue close through the PR merge.
 - After the PR is merged, delete the remote feature branch and remove the local branch or worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Shared skill references live in `references/abo-assistant/`. Keep AGENTS.md focu
 - Create a dedicated branch from `master` for each issue before editing files. Start from a fresh remote base with `git fetch origin master` and `git switch -c <branch> origin/master`.
 - Use descriptive branch prefixes by work type: `feature/<short-name>` for features, `fix/<short-name>` for bug fixes, `docs/<short-name>` for documentation-only changes, and `chore/<short-name>` for maintainer/tooling work.
 - Verify the active branch with `git status --short --branch` before editing, committing, or pushing. Do not commit or push from `master` except for explicitly approved tiny edits or explicit repository maintenance such as an approved history rewrite.
-- `master` is protected. Normal work must merge through a pull request with required checks passing and one approving review. Admin enforcement is enabled; do not bypass protection for normal work.
+- `master` is protected. Normal work must merge through a pull request with required checks passing. Repository auto-merge is enabled for the single-maintainer workflow, so do not require a separate approval unless branch protection is intentionally changed. Admin enforcement is enabled; do not bypass protection for normal work.
 - Keep the issue updated while working. Add comments for scope changes, important implementation decisions, blockers, test results, and follow-up work discovered during implementation.
 - Keep commits focused on the issue. Do not mix unrelated cleanup, refactors, or separate features into the same branch.
 - As part of each feature or fix, decide whether tests, docs, and `CHANGELOG.md` need updates. If they do, include them in the same branch. If they do not, note why in the PR.
@@ -76,7 +76,7 @@ Shared skill references live in `references/abo-assistant/`. Keep AGENTS.md focu
 - When pre-commit hooks are configured, prefer `prek run --all-files` over `pre-commit run --all-files`. If hooks are installed locally but no config exists on the branch, report that instead of treating hook execution as required.
 - When creating a separate Git worktree, install both pre-commit and commit-message hooks in that worktree when hook config exists, for example `prek install --hook-type pre-commit --hook-type commit-msg`.
 - Open a pull request into `master` when the branch is ready. The PR body must include the issue it resolves, a short summary, tests run, docs/changelog status, and any follow-up issues created.
-- Repository auto-merge is enabled. When checks are green and the only blocker is required review, enable auto-merge with squash merge and delete the branch after merge; then report that human approval is the remaining blocker.
+- Repository auto-merge is enabled. When required checks are green and the PR is otherwise mergeable, enable auto-merge with squash merge and delete the branch after merge. If GitHub reports `REVIEW_REQUIRED`, treat branch protection as out of sync with the single-maintainer workflow and report the configuration blocker.
 - Prefer Squash and merge for PRs unless the maintainer asks for another merge strategy.
 - A feature, fix, docs, or chore issue is not complete at local commit or draft PR time. Close the cycle by getting the PR ready, passing required checks, merging back into `master`, and letting the linked issue close through the PR merge.
 - After the PR is merged, delete the remote feature branch and remove the local branch or worktree.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split the Audiobookshelf E2E matrix into parallel GitHub Actions jobs for faster feedback.
 - Added a first-class Audiobookshelf smoke/reset matrix row for the reset, baseline restore, startup, scan, metadata setting, and initial item count contract.
 - Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, branch verification, and closeout through merge back to `master`.
-- Documented protected `master` workflow rules for required review, auto-merge, and branch cleanup.
+- Documented protected `master` workflow rules for required checks, auto-merge, and branch cleanup.
 - Refined the `abo-workflow` skill to prompt between creating new tracked work and selecting from existing GitHub issues.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split the Audiobookshelf E2E matrix into parallel GitHub Actions jobs for faster feedback.
 - Added a first-class Audiobookshelf smoke/reset matrix row for the reset, baseline restore, startup, scan, metadata setting, and initial item count contract.
 - Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, branch verification, and closeout through merge back to `master`.
+- Documented protected `master` workflow rules for required review, auto-merge, and branch cleanup.
 - Refined the `abo-workflow` skill to prompt between creating new tracked work and selecting from existing GitHub issues.
 
 ---

--- a/references/abo-assistant/common.md
+++ b/references/abo-assistant/common.md
@@ -10,7 +10,7 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - Work on a dedicated branch from `origin/master` before editing; do not push directly to `master`.
 - Use branch prefixes by work type: `feature/<short-name>`, `fix/<short-name>`, `docs/<short-name>`, or `chore/<short-name>`.
 - Verify `git status --short --branch` before editing, committing, or pushing.
-- `master` is protected with required checks and one required approving review. Admin enforcement is enabled; do not bypass protection for normal work.
+- `master` is protected with required checks. Repository auto-merge is enabled for the single-maintainer workflow, so a separate approving review is not required unless branch protection is intentionally changed. Admin enforcement is enabled; do not bypass protection for normal work.
 - If a separate Git worktree is created and hook config exists, run `prek install --hook-type pre-commit --hook-type commit-msg` inside that worktree.
 - Preserve unrelated dirty worktree changes.
 - Keep edits focused on the issue.
@@ -18,7 +18,7 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - User-visible features, fixes, behavior changes, Docker/runtime changes, and documentation changes need a `CHANGELOG.md` entry under `Unreleased`.
 - ABS-facing behavior changes must update `test/abs/test-matrix.md` unless explicitly not applicable.
 - PRs target `master`; prefer Squash and merge; issues normally close through PR merge.
-- Repository auto-merge and delete-branch-on-merge are enabled. When checks are green and required review is the only blocker, enable auto-merge and report that approval is pending.
+- Repository auto-merge and delete-branch-on-merge are enabled. When required checks are green and the PR is otherwise mergeable, enable auto-merge. If GitHub reports `REVIEW_REQUIRED`, report the branch protection mismatch instead of trying to self-approve.
 - Do not treat a local commit or draft PR as done. Finish the cycle by getting the PR ready, passing required checks, enabling or completing merge back into `master`, confirming the linked issue closed, and cleaning up the branch or worktree.
 
 ## Architecture Map

--- a/references/abo-assistant/common.md
+++ b/references/abo-assistant/common.md
@@ -10,6 +10,7 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - Work on a dedicated branch from `origin/master` before editing; do not push directly to `master`.
 - Use branch prefixes by work type: `feature/<short-name>`, `fix/<short-name>`, `docs/<short-name>`, or `chore/<short-name>`.
 - Verify `git status --short --branch` before editing, committing, or pushing.
+- `master` is protected with required checks and one required approving review. Admin enforcement is enabled; do not bypass protection for normal work.
 - If a separate Git worktree is created and hook config exists, run `prek install --hook-type pre-commit --hook-type commit-msg` inside that worktree.
 - Preserve unrelated dirty worktree changes.
 - Keep edits focused on the issue.
@@ -17,7 +18,8 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - User-visible features, fixes, behavior changes, Docker/runtime changes, and documentation changes need a `CHANGELOG.md` entry under `Unreleased`.
 - ABS-facing behavior changes must update `test/abs/test-matrix.md` unless explicitly not applicable.
 - PRs target `master`; prefer Squash and merge; issues normally close through PR merge.
-- Do not treat a local commit or draft PR as done. Finish the cycle by getting the PR ready, passing required checks, merging back into `master`, confirming the linked issue closed, and cleaning up the branch or worktree.
+- Repository auto-merge and delete-branch-on-merge are enabled. When checks are green and required review is the only blocker, enable auto-merge and report that approval is pending.
+- Do not treat a local commit or draft PR as done. Finish the cycle by getting the PR ready, passing required checks, enabling or completing merge back into `master`, confirming the linked issue closed, and cleaning up the branch or worktree.
 
 ## Architecture Map
 

--- a/references/abo-assistant/pr.md
+++ b/references/abo-assistant/pr.md
@@ -12,6 +12,7 @@ Use this shared reference for PR writing, creation, watching, and closeout.
 - Pre-commit hooks have been run with `prek run --all-files` when hook config exists, or their absence is documented.
 - User-visible changes have a `CHANGELOG.md` entry under `Unreleased`.
 - ABS-facing changes update `test/abs/test-matrix.md` when relevant.
+- `master` branch protection requires all configured checks to pass and one approving review before merge.
 
 ## PR Body Shape
 
@@ -30,15 +31,17 @@ Prefer concise reviewer-oriented text. Do not hide unrun tests.
 - `gh pr view --json number,title,state,url,baseRefName,headRefName,isDraft,mergeStateStatus,statusCheckRollup`
 - `gh pr checks <number>`
 - `gh pr diff <number>`
-- `gh pr create --base master --head <branch> --draft --title "<title>" --body-file <file>`
+- `gh pr create --base master --head <branch> --title "<title>" --body-file <file>`
+- `gh pr merge <number> --auto --squash --delete-branch`
 
 Prefer `--body-file` over `--fill` so issue links, test notes, and changelog status are preserved.
 Prefer Squash and merge when the PR is ready unless the maintainer asks for another merge strategy.
+Prefer enabling auto-merge once checks are green. If GitHub reports `REVIEW_REQUIRED`, report that human approval is the remaining blocker; do not bypass branch protection.
 
 ## Closeout Rules
 
 - Issues normally close through PR merge back into `master`.
-- A branch is not done when implementation is committed, pushed, or opened as a draft PR. Closeout means the PR is ready, required checks and review are satisfied, the PR is merged, the linked issue closes, and stale branches or worktrees are cleaned up.
+- A branch is not done when implementation is committed, pushed, or opened as a PR. Closeout means the PR is ready, required checks pass, required review is satisfied or auto-merge is enabled while review is pending, the PR merges, the linked issue closes, and stale branches or worktrees are cleaned up.
 - Use closing keywords in the PR body when the PR fully resolves the issue.
 - Directly close an issue only when the user explicitly asks, the issue is obsolete/duplicate, or the work intentionally completed outside PR merge.
 - Before closeout, verify acceptance criteria against code, tests, docs, changelog, and PR state.
@@ -49,4 +52,5 @@ Prefer Squash and merge when the PR is ready unless the maintainer asks for anot
 2. Classify findings as CI failure, requested change, maintainer question, docs/changelog gap, stale branch, or follow-up.
 3. Apply mechanical or clearly requested fixes.
 4. Ask before risky rebases, behavior changes, or ambiguous maintainer feedback.
-5. Summarize what changed, what remains blocked, and which checks should rerun.
+5. If checks are green and only required review blocks merge, enable auto-merge with squash/delete-branch when available.
+6. Summarize what changed, what remains blocked, and which checks should rerun.

--- a/references/abo-assistant/pr.md
+++ b/references/abo-assistant/pr.md
@@ -12,7 +12,7 @@ Use this shared reference for PR writing, creation, watching, and closeout.
 - Pre-commit hooks have been run with `prek run --all-files` when hook config exists, or their absence is documented.
 - User-visible changes have a `CHANGELOG.md` entry under `Unreleased`.
 - ABS-facing changes update `test/abs/test-matrix.md` when relevant.
-- `master` branch protection requires all configured checks to pass and one approving review before merge.
+- `master` branch protection requires all configured checks to pass before merge. Repository auto-merge is enabled for the single-maintainer workflow, so a separate approving review is not required unless branch protection is intentionally changed.
 
 ## PR Body Shape
 
@@ -36,12 +36,12 @@ Prefer concise reviewer-oriented text. Do not hide unrun tests.
 
 Prefer `--body-file` over `--fill` so issue links, test notes, and changelog status are preserved.
 Prefer Squash and merge when the PR is ready unless the maintainer asks for another merge strategy.
-Prefer enabling auto-merge once checks are green. If GitHub reports `REVIEW_REQUIRED`, report that human approval is the remaining blocker; do not bypass branch protection.
+Prefer enabling auto-merge once checks are green. If GitHub reports `REVIEW_REQUIRED`, report that branch protection is out of sync with the single-maintainer workflow; do not bypass branch protection.
 
 ## Closeout Rules
 
 - Issues normally close through PR merge back into `master`.
-- A branch is not done when implementation is committed, pushed, or opened as a PR. Closeout means the PR is ready, required checks pass, required review is satisfied or auto-merge is enabled while review is pending, the PR merges, the linked issue closes, and stale branches or worktrees are cleaned up.
+- A branch is not done when implementation is committed, pushed, or opened as a PR. Closeout means the PR is ready, required checks pass, auto-merge is enabled or the PR merges, the linked issue closes, and stale branches or worktrees are cleaned up.
 - Use closing keywords in the PR body when the PR fully resolves the issue.
 - Directly close an issue only when the user explicitly asks, the issue is obsolete/duplicate, or the work intentionally completed outside PR merge.
 - Before closeout, verify acceptance criteria against code, tests, docs, changelog, and PR state.
@@ -52,5 +52,5 @@ Prefer enabling auto-merge once checks are green. If GitHub reports `REVIEW_REQU
 2. Classify findings as CI failure, requested change, maintainer question, docs/changelog gap, stale branch, or follow-up.
 3. Apply mechanical or clearly requested fixes.
 4. Ask before risky rebases, behavior changes, or ambiguous maintainer feedback.
-5. If checks are green and only required review blocks merge, enable auto-merge with squash/delete-branch when available.
+5. If required checks are green and the PR is otherwise mergeable, enable auto-merge with squash/delete-branch when available.
 6. Summarize what changed, what remains blocked, and which checks should rerun.


### PR DESCRIPTION
Resolves #57

## Summary

- Document that `master` is protected with required checks and one approving review.
- Update shared PR workflow guidance to use auto-merge when checks are green and review is the remaining blocker.
- Update PR creation, watching, closeout, and coordinator skills for the protected-branch workflow.
- Document repository delete-branch-on-merge behavior and branch cleanup verification.

## Tests

- `git diff --check`
- `prek run --all-files`
- Commit hooks: trailing whitespace, EOF, YAML, large file, merge conflict, private key, mixed line ending, conventional commit

## Docs, Changelog, ABS

- Docs: updated `AGENTS.md`, repo-local skills, and shared PR/common references.
- Changelog: added an Unreleased workflow documentation entry.
- ABS matrix: not applicable; documentation-only workflow update.

## Notes

- The working tree has an unrelated untracked `docs/logo2.png` that is not included in this PR.
