### PR TITLE
Improve repository SEO and discoverability metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed the deprecated GUI tree and release packaging. Releases now focus on one `audiobook-organizer` binary with CLI, TUI, ABS, and local web UI entrypoints.
+- Improved README, repository metadata, and web page metadata so search results describe the project as an audiobook organizer and renamer for Audiobookshelf with `metadata.json`, EPUB, MP3, and M4B support.
 - Rewrote the root README for the single-binary web UI direction and current command surface.
 - Split the Audiobookshelf E2E matrix into parallel GitHub Actions jobs for faster feedback.
 - Added a first-class Audiobookshelf smoke/reset matrix row for the reset, baseline restore, startup, scan, metadata setting, and initial item count contract.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Audiobook Organizer
 
+Audiobook Organizer for Audiobookshelf organizes and renames audiobook libraries using metadata from `metadata.json`, EPUB, MP3, and M4B files.
+
 [![codecov](https://codecov.io/gh/jeeftor/audiobook-organizer/branch/master/graph/badge.svg)](https://codecov.io/gh/jeeftor/audiobook-organizer)
 [![Coverage Status](https://coveralls.io/repos/github/jeeftor/audiobook-organizer/badge.svg?branch=master)](https://coveralls.io/github/jeeftor/audiobook-organizer?branch=master)
 
 ![Audiobook Organizer logo](docs/logo.png)
 
-Audiobook Organizer is a single-binary tool for cleaning up audiobook libraries. It can preview and organize folders, rename files from metadata templates, inspect metadata, and connect to Audiobookshelf for library metadata and scan workflows.
+It is a single-binary audiobook library management tool for cleaning up folders, previewing file moves, renaming audiobook files from metadata templates, inspecting metadata, and connecting to Audiobookshelf for library metadata and scan workflows.
 
 The project now ships one `audiobook-organizer` binary with:
 
@@ -15,11 +17,19 @@ The project now ships one `audiobook-organizer` binary with:
 
 `audiobook-organizer gui` remains as a compatibility alias for `audiobook-organizer web`.
 
-## What It Does
+Common audiobook workflows:
+
+- [Organize audiobook libraries](docs/CLI.md) into layouts such as `Author/Series/Title`.
+- [Rename audiobook files](docs/RENAME_FEATURE.md) with metadata templates and dry-run previews.
+- [Use Audiobookshelf metadata and scan workflows](#audiobookshelf-workflows).
+- [Read metadata from metadata.json, EPUB, MP3, and M4B files](docs/METADATA.md).
+- [Install with Homebrew, Go, Docker, or release packages](docs/INSTALLATION.md).
+
+## Audiobook Organization And Rename Features
 
 - Organizes audiobooks into predictable directory layouts such as `Author/Series/Title`.
-- Reads metadata from `metadata.json`, EPUB, MP3, M4B, and Audiobookshelf.
-- Renames files with templates such as `{author} - {series} {series_number} - {title}`.
+- Reads audiobook metadata from `metadata.json`, EPUB, MP3, M4B, and Audiobookshelf.
+- Renames audiobook files with templates such as `{author} - {series} {series_number} - {title}`.
 - Supports dry-run previews before filesystem changes.
 - Logs organization and rename operations for undo.
 - Handles field mapping for non-standard metadata tags.

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -3,7 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Audiobook Organizer</title>
+    <title>Audiobook Organizer for Audiobookshelf</title>
+    <meta
+      name="description"
+      content="Organize and rename audiobook libraries for Audiobookshelf using metadata.json, EPUB, MP3, and M4B metadata."
+    />
+    <meta property="og:title" content="Audiobook Organizer for Audiobookshelf" />
+    <meta
+      property="og:description"
+      content="Preview, organize, and rename audiobook libraries with metadata.json, EPUB, MP3, M4B, and Audiobookshelf workflows."
+    />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Audiobook Organizer for Audiobookshelf" />
+    <meta
+      name="twitter:description"
+      content="Organize and rename audiobook libraries with metadata.json, EPUB, MP3, M4B, and Audiobookshelf support."
+    />
     <script type="module" crossorigin src="/assets/index-D-o5L5U4.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-BOFz3h-g.css">
   </head>

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Audiobook Organizer</title>
+    <title>Audiobook Organizer for Audiobookshelf</title>
+    <meta
+      name="description"
+      content="Organize and rename audiobook libraries for Audiobookshelf using metadata.json, EPUB, MP3, and M4B metadata."
+    />
+    <meta property="og:title" content="Audiobook Organizer for Audiobookshelf" />
+    <meta
+      property="og:description"
+      content="Preview, organize, and rename audiobook libraries with metadata.json, EPUB, MP3, M4B, and Audiobookshelf workflows."
+    />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Audiobook Organizer for Audiobookshelf" />
+    <meta
+      name="twitter:description"
+      content="Organize and rename audiobook libraries with metadata.json, EPUB, MP3, M4B, and Audiobookshelf support."
+    />
   </head>
   <body style="margin: 0; background: #0f1115; color: #eef3f8">
     <div id="app"></div>


### PR DESCRIPTION
Resolves #61

## Summary

- Rewrite the README opening and early workflow links so search results and repo visitors see "Audiobook Organizer for Audiobookshelf" plus rename, `metadata.json`, EPUB, MP3, and M4B support.
- Add browser, Open Graph, and Twitter metadata to the Vite source HTML and checked-in embedded static HTML.
- Record the discoverability update in `CHANGELOG.md`.
- Updated GitHub repository metadata directly: description now reads "Organize and rename audiobook libraries for Audiobookshelf using metadata.json, EPUB, MP3, and M4B metadata." and topics now include audiobook, audiobookshelf, audiobook-organizer, audiobook-renamer, m4b, mp3, epub, metadata-json, library-management, and golang.

## Tests

- `npm run build`
- `prek run --all-files`
- `git diff --check`

## Docs And Changelog

- README updated.
- CHANGELOG.md updated under Unreleased.
- ABS matrix not applicable; this is docs/search metadata only and does not change ABS-facing behavior.

## Follow-Up

- A dedicated GitHub Pages/docs landing page could further improve Google indexing, but this PR intentionally keeps scope to the easy repo-visible fixes.
