### PR TITLE
Fix staged web UI mobile smoke test

### DIFF
--- a/.agents/skills/abo-tests/SKILL.md
+++ b/.agents/skills/abo-tests/SKILL.md
@@ -19,7 +19,12 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 4. For bug fixes, create or identify a failing check first when practical.
 5. Prefer focused package tests, then widen to repo-native checks.
 6. Run `prek run --all-files` when pre-commit hooks are configured.
-7. Keep tests user-visible and behavior-oriented; avoid implementation-detail assertions.
-8. Report exact commands, status, and blockers.
+7. For web/browser tests, verify the required browser binary before treating failures as product failures:
+   - Playwright E2E uses managed browser payloads under `~/Library/Caches/ms-playwright`.
+   - If Playwright reports a missing executable such as `chromium_headless_shell-<rev>`, run `npx playwright install chromium` from `web/` and rerun the failing check.
+   - A separate cached Chrome Headless Shell may exist under `~/.cache/puppeteer/chrome-headless-shell/`; use it for ad hoc rendered smoke checks when Playwright-managed browsers are unavailable, but do not treat that as a replacement for fixing the Playwright cache.
+   - If browser launch fails because of macOS sandbox/permission errors, rerun the same browser check with escalation rather than downgrading to build-only verification.
+8. Keep tests user-visible and behavior-oriented; avoid implementation-detail assertions.
+9. Report exact commands, status, browser binary path used, and blockers.
 
 Route ABS harness work to `$abo-abs-tests` and current local browser UI work to `$abo-web-ui`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, branch verification, and closeout through merge back to `master`.
 - Documented protected `master` workflow rules for required checks, auto-merge, and branch cleanup.
 - Refined the `abo-workflow` skill to prompt between creating new tracked work and selecting from existing GitHub issues.
+- Documented browser binary setup for local web UI E2E checks, including Playwright-managed Chromium and cached Chrome Headless Shell fallback behavior.
 - Restructured the local web UI into explicit organize, rename, and Audiobookshelf workflow stages so configure, dry-run preview, run, and review states are separated.
 
 ---

--- a/references/abo-assistant/testing.md
+++ b/references/abo-assistant/testing.md
@@ -30,8 +30,19 @@ The current web UI is the local browser UI:
 - Build embedded assets: `make web-build`.
 - Run frontend dev server: `make web-dev`.
 - Full distribution build: `make build`.
+- Browser E2E: `cd web && npm run test:e2e`.
 
 If `web/` is absent on an older checkout, stop and report that the checkout does not contain the current new web UI design.
+
+### Browser Binary Setup
+
+Before reporting a browser E2E failure as an application failure, confirm the browser binary that the check needs:
+
+- Playwright-managed browsers live under `~/Library/Caches/ms-playwright`.
+- The repo web E2E suite expects Playwright's managed Chromium and Chrome Headless Shell revisions. If `npm run test:e2e` fails with a missing executable under `~/Library/Caches/ms-playwright`, run `npx playwright install chromium` from `web/`, then rerun the check.
+- A separate Chrome Headless Shell may exist under `~/.cache/puppeteer/chrome-headless-shell/`. Use it for temporary rendered smoke checks when Playwright-managed browsers are missing, and record the exact executable path, but still install the Playwright-managed payload for the repo E2E suite.
+- If Chrome Headless Shell launch fails with macOS sandbox or `MachPortRendezvousServer` permission errors, rerun the same browser check with command escalation. Do not reduce verification to `make web-build` only when rendered UI behavior is under test.
+- When reporting results, include whether the check used Playwright-managed Chromium or the cached Chrome Headless Shell fallback.
 
 ## ABS Checks
 

--- a/web/tests/e2e/gui-smoke.spec.ts
+++ b/web/tests/e2e/gui-smoke.spec.ts
@@ -57,7 +57,6 @@ test('separates workflow modes and gates run behind preview review', async ({ pa
   await page.getByRole('button', { name: /Mark Preview Reviewed/ }).click()
   await expect(page.getByRole('heading', { name: 'Execute the reviewed plan' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Run Rename' })).toBeEnabled()
-  await expect(page.getByText('Preview reviewed')).toBeVisible()
 })
 
 async function loadApp(page: Page): Promise<void> {


### PR DESCRIPTION
Resolves #63

## Summary

- Fixes the staged web UI smoke test so it no longer expects the desktop-only activity panel to be visible on mobile.
- Documents the browser binary setup required for local web UI E2E checks, including Playwright-managed Chromium and the cached Chrome Headless Shell fallback.

## Tests

- `cd web && npm run test:e2e`
- `prek run --all-files`

## Notes

- The Playwright-managed Chromium payload was installed locally with `npx playwright install chromium` before rerunning the web E2E suite.
- Docs/changelog: `CHANGELOG.md`, `$abo-tests`, and `references/abo-assistant/testing.md` updated.
- ABS matrix: not applicable; this only changes a web smoke test assertion and maintainer test guidance.
