### PR TITLE
Require real E2E acceptance coverage in ABO skills

### DIFF
--- a/.agents/skills/abo-abs-tests/SKILL.md
+++ b/.agents/skills/abo-abs-tests/SKILL.md
@@ -19,6 +19,7 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 4. Preserve the reset contract: stop containers, rebuild runtime fixtures, restore committed baseline config, start containers, and scan.
 5. Never restore SQLite state while ABS containers are running.
 6. Prefer focused `go test -tags=abs_e2e ./test/abs/e2e -run TestName -count=1 -v`, then `make abs-test-matrix` when practical.
-7. If Docker, downloads, or certificates block validation, report the exact command and blocker.
+7. Do not treat mocked ABS responses as acceptance evidence for ABS-facing behavior; real E2E must verify containers, fixtures, and ABS API or database state unless the maintainer explicitly accepts a documented blocker.
+8. If Docker, downloads, or certificates block validation, report the exact command and blocker.
 
 ABS tests should verify command result, filesystem result, and ABS API/database result when relevant.

--- a/.agents/skills/abo-feature/SKILL.md
+++ b/.agents/skills/abo-feature/SKILL.md
@@ -19,8 +19,9 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 4. Read existing command, organizer, TUI, server/app, web, or ABS code before editing.
 5. Prefer existing patterns and helpers over new abstractions.
 6. Add or update tests that prove the new behavior.
-7. Update docs, `CHANGELOG.md`, and `test/abs/test-matrix.md` when applicable.
-8. Run focused verification, then wider checks when practical.
-9. Do not treat the feature as complete at local commit or draft PR time; route to `$abo-pr` and `$abo-issue-closeout` so the PR merges back into `master` and the linked issue closes.
+7. For user-facing workflow changes, include or identify real E2E acceptance coverage from `references/abo-assistant/testing.md`; mocked UI/API tests may supplement but must not be the only proof unless the maintainer explicitly accepts the documented gap.
+8. Update docs, `CHANGELOG.md`, and `test/abs/test-matrix.md` when applicable.
+9. Run focused verification, then wider checks when practical.
+10. Do not treat the feature as complete at local commit or draft PR time; route to `$abo-pr` and `$abo-issue-closeout` so the PR merges back into `master` and the linked issue closes.
 
 Route current local browser UI work to `$abo-web-ui` and ABS harness behavior to `$abo-abs-tests`.

--- a/.agents/skills/abo-issue-closeout/SKILL.md
+++ b/.agents/skills/abo-issue-closeout/SKILL.md
@@ -16,11 +16,12 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 1. Run `$abo-issue-verify` logic first: issue criteria, branch diff, tests, docs, changelog, and ABS matrix.
 2. Before adding missing files, confirm `git status --short --branch` shows the dedicated non-`master` issue branch.
 3. Add missing `CHANGELOG.md`, docs, or `test/abs/test-matrix.md` updates when required.
-4. Comment on the issue with what changed, tests run, and any follow-up work.
-5. If a PR will close the issue, ensure the PR body uses `Resolves #<issue>` and do not manually close it.
-6. Treat the issue as open until the resolving PR is ready, required checks pass, auto-merge is enabled or the PR has merged back into `master`, and the linked issue has closed.
-7. After merge, confirm the linked issue closed and the feature branch or worktree was cleaned up. Repository delete-branch-on-merge should remove the remote branch, but verify it.
-8. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
-9. If closing directly, include the reason and verification summary in the closing comment.
+4. Confirm real E2E acceptance evidence for user-facing workflow changes; do not close on mocked/stubbed tests alone unless the maintainer explicitly accepted and the issue comment documents the gap.
+5. Comment on the issue with what changed, tests run, and any follow-up work.
+6. If a PR will close the issue, ensure the PR body uses `Resolves #<issue>` and do not manually close it.
+7. Treat the issue as open until the resolving PR is ready, required checks pass, auto-merge is enabled or the PR has merged back into `master`, and the linked issue has closed.
+8. After merge, confirm the linked issue closed and the feature branch or worktree was cleaned up. Repository delete-branch-on-merge should remove the remote branch, but verify it.
+9. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
+10. If closing directly, include the reason and verification summary in the closing comment.
 
 Do not close an issue with failing or unrun required checks unless the user explicitly accepts the risk and the reason is documented.

--- a/.agents/skills/abo-issue-verify/SKILL.md
+++ b/.agents/skills/abo-issue-verify/SKILL.md
@@ -19,8 +19,9 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 4. Verify each criterion against code, tests, docs, and behavior.
 5. Check whether `CHANGELOG.md` is required and present.
 6. Check whether `test/abs/test-matrix.md` is required and present for ABS-facing changes.
-7. Run or confirm the narrowest relevant verification commands, widening when practical.
-8. Verify whether the work is only locally complete or fully closed out through a PR merge back into `master`.
-9. Report a checklist of pass/fail/blocked items and the exact remaining work.
+7. For user-facing workflow changes, verify that real E2E acceptance coverage exists and was run; classify mocked/stubbed UI or API tests as supplemental only.
+8. Run or confirm the narrowest relevant verification commands, widening when practical.
+9. Verify whether the work is only locally complete or fully closed out through a PR merge back into `master`.
+10. Report a checklist of pass/fail/blocked items and the exact remaining work.
 
 Do not mark the issue done just because tests pass. Tie completion back to acceptance criteria and repo workflow obligations.

--- a/.agents/skills/abo-tests/SKILL.md
+++ b/.agents/skills/abo-tests/SKILL.md
@@ -19,12 +19,13 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 4. For bug fixes, create or identify a failing check first when practical.
 5. Prefer focused package tests, then widen to repo-native checks.
 6. Run `prek run --all-files` when pre-commit hooks are configured.
-7. For web/browser tests, verify the required browser binary before treating failures as product failures:
+7. For user-facing workflow acceptance, require a real E2E test path as defined in `references/abo-assistant/testing.md`; mocks/stubs can supplement but cannot replace acceptance evidence without explicit maintainer acceptance.
+8. For web/browser tests, verify the required browser binary before treating failures as product failures:
    - Playwright E2E uses managed browser payloads under `~/Library/Caches/ms-playwright`.
    - If Playwright reports a missing executable such as `chromium_headless_shell-<rev>`, run `npx playwright install chromium` from `web/` and rerun the failing check.
    - A separate cached Chrome Headless Shell may exist under `~/.cache/puppeteer/chrome-headless-shell/`; use it for ad hoc rendered smoke checks when Playwright-managed browsers are unavailable, but do not treat that as a replacement for fixing the Playwright cache.
    - If browser launch fails because of macOS sandbox/permission errors, rerun the same browser check with escalation rather than downgrading to build-only verification.
-8. Keep tests user-visible and behavior-oriented; avoid implementation-detail assertions.
-9. Report exact commands, status, browser binary path used, and blockers.
+9. Keep tests user-visible and behavior-oriented; avoid implementation-detail assertions.
+10. Report exact commands, status, browser binary path used, and blockers.
 
 Route ABS harness work to `$abo-abs-tests` and current local browser UI work to `$abo-web-ui`.

--- a/.agents/skills/abo-web-ui/SKILL.md
+++ b/.agents/skills/abo-web-ui/SKILL.md
@@ -19,7 +19,9 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 4. Preserve loopback-only server behavior and session token checks.
 5. Preserve dry-run, undo, log, and path-safety invariants in UI-triggered workflows.
 6. Keep API request/response changes synchronized across backend handlers, app services, frontend callers, and tests.
-7. Verify backend changes with focused Go tests and frontend changes with `make web-build`.
-8. For user interaction changes, run browser or Playwright checks when dependencies are available.
+7. For user-facing workflow acceptance, use Playwright or equivalent browser automation against the real local server and real filesystem or service fixtures for the endpoint under test.
+8. Do not mock or intercept the primary workflow endpoint being accepted, such as organize preview/run, rename preview, or ABS operation endpoints; mocked browser routes are allowed only as supplemental UI-contract or error-state checks.
+9. Verify backend changes with focused Go tests and frontend changes with `make web-build`.
+10. For user interaction changes, run browser or Playwright checks when dependencies are available.
 
 Keep this skill focused on the current local browser UI paths only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented protected `master` workflow rules for required checks, auto-merge, and branch cleanup.
 - Refined the `abo-workflow` skill to prompt between creating new tracked work and selecting from existing GitHub issues.
 - Documented browser binary setup for local web UI E2E checks, including Playwright-managed Chromium and cached Chrome Headless Shell fallback behavior.
+- Clarified maintainer workflow guidance so user-facing workflow issues require real E2E acceptance evidence, while mocked UI/API tests remain supplemental.
 - Restructured the local web UI into explicit organize, rename, and Audiobookshelf workflow stages so configure, dry-run preview, run, and review states are separated.
 - Improved local web UI startup handling so config/options loading and fallback states are visible and Audiobookshelf metadata mode stays scoped to the ABS workflow.
 - Wired the local web UI organize workflow to real preview and run endpoints with review gating and backend result summaries.

--- a/references/abo-assistant/pr.md
+++ b/references/abo-assistant/pr.md
@@ -9,6 +9,7 @@ Use this shared reference for PR writing, creation, watching, and closeout.
 - Branch is tied to a GitHub issue.
 - Unrelated dirty worktree changes are not included.
 - Relevant tests, lint, and builds have been run or explicitly documented as blocked.
+- User-facing workflow changes have real E2E acceptance evidence; mocked UI/API tests are supplemental only unless the maintainer explicitly accepted the documented gap.
 - Pre-commit hooks have been run with `prek run --all-files` when hook config exists, or their absence is documented.
 - User-visible changes have a `CHANGELOG.md` entry under `Unreleased`.
 - ABS-facing changes update `test/abs/test-matrix.md` when relevant.
@@ -21,6 +22,7 @@ Include:
 - `Resolves #<issue>`
 - Summary.
 - Tests run, with exact commands.
+- Real E2E evidence for user-facing workflow changes, or the maintainer-accepted reason it is blocked.
 - Docs/changelog status.
 - Follow-up issues or known gaps, if any.
 
@@ -45,6 +47,7 @@ Prefer enabling auto-merge once checks are green. If GitHub reports `REVIEW_REQU
 - Use closing keywords in the PR body when the PR fully resolves the issue.
 - Directly close an issue only when the user explicitly asks, the issue is obsolete/duplicate, or the work intentionally completed outside PR merge.
 - Before closeout, verify acceptance criteria against code, tests, docs, changelog, and PR state.
+- Do not close a user-facing workflow issue based only on mocked/stubbed tests. Confirm real E2E evidence or documented maintainer acceptance of the gap.
 
 ## Watcher Duties
 

--- a/references/abo-assistant/testing.md
+++ b/references/abo-assistant/testing.md
@@ -2,6 +2,25 @@
 
 Use repo-native checks first. Start narrow, then widen before PR closeout when practical.
 
+## Real E2E Acceptance Rule
+
+For user-facing workflow changes, acceptance-level validation must include a real
+end-to-end path before the issue is considered complete. A real E2E check drives
+the actual entrypoint under test and verifies real downstream effects:
+
+- Browser/web workflow: browser -> local web server -> real API handler -> real
+  app/core behavior -> real filesystem fixture or external service result.
+- CLI/TUI workflow: command or TUI path -> real organizer/renamer behavior ->
+  real filesystem fixture result.
+- ABS workflow: command or REST path -> real ABS container/API/database behavior
+  -> real filesystem and ABS state result.
+
+Mocked browser routes, stubbed API responses, fake ABS clients, and synthetic
+UI-only state tests are useful supplemental UI-contract checks, but they do not
+replace real E2E acceptance evidence for a full feature or fix issue. If a real
+E2E check is blocked, leave the issue open or document the blocker and get
+explicit maintainer acceptance before treating the gap as acceptable.
+
 ## Core Checks
 
 - Format Go code: `make fmt`
@@ -34,6 +53,13 @@ The current web UI is the local browser UI:
 
 If `web/` is absent on an older checkout, stop and report that the checkout does not contain the current new web UI design.
 
+For web workflow issues, prefer fixture-backed Playwright tests that use the real
+server endpoints for the behavior under test. Do not mock or intercept the
+primary endpoint being accepted, such as `/api/organize/preview`,
+`/api/organize/run`, `/api/rename/preview`, or ABS operation endpoints. Mocked
+routes may still be used for negative UI states, bootstrap failures, or contract
+tests, but label/report them as supplemental rather than full E2E proof.
+
 ### Browser Binary Setup
 
 Before reporting a browser E2E failure as an application failure, confirm the browser binary that the check needs:
@@ -56,6 +82,10 @@ ABS-facing changes include Audiobookshelf discovery, path mapping, metadata mode
 - Focused ABS test: `go test -tags=abs_e2e ./test/abs/e2e -run TestName -count=1 -v`
 
 ABS tests require Docker and can download public-domain fixtures. If Docker, network, or corporate proxy/certificates block the run, report the exact blocker and command attempted.
+
+ABS acceptance checks should use real containers, committed/runtime fixtures, and
+real ABS API or database state. Mocked ABS responses can supplement UI or error
+handling tests, but they are not sufficient to close ABS-facing behavior issues.
 
 ## Test Selection
 


### PR DESCRIPTION
Resolves #82

Summary:
- Add a Real E2E Acceptance Rule to the shared ABO testing reference.
- Update feature, web UI, test, ABS, issue verification, closeout, and PR guidance so mocked UI/API tests are supplemental only.
- Clarify that Playwright should drive the real local server and real fixtures for web workflow acceptance.

Tests:
- prek run --all-files

Docs/changelog:
- Updated repo-local skills and shared references.
- Added an Unreleased changelog entry for the maintainer workflow change.
