### PR TITLE
Add real organize web E2E coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Beta release tags now derive from the latest stable SemVer tag instead of stacking beta suffixes from prior prereleases.
 - Frontend embed path is now stable for goreleaser by building into `internal/server/static`.
 - Release workflows build the web frontend before packaging the single binary.
+- Organize summaries now report directories missing metadata even when verbose console logging is disabled, so web previews show real warning counts.
 
 ### Changed
 

--- a/internal/app/organize_test.go
+++ b/internal/app/organize_test.go
@@ -31,6 +31,21 @@ func TestPreviewOrganizeForcesDryRunAndOmitsLogPath(t *testing.T) {
 	assertFileNotExists(t, filepath.Join(outputDir, "App Author", "App Test Book", "audio.mp3"))
 }
 
+func TestPreviewOrganizeReportsMetadataMissingWithoutVerbose(t *testing.T) {
+	service := NewService(DefaultWebConfig("127.0.0.1", 0, false, "", ""))
+	inputDir, outputDir, missingDir := createOrganizeFixtureWithMissingMetadata(t)
+
+	resp, err := service.PreviewOrganize(context.Background(), OrganizeRequest{
+		Config: organizeTestConfig(inputDir, outputDir, false),
+	})
+	if err != nil {
+		t.Fatalf("PreviewOrganize() error = %v", err)
+	}
+
+	assertStringSliceContains(t, resp.Summary.MetadataMissing, mustResolvePath(t, inputDir))
+	assertStringSliceContains(t, resp.Summary.MetadataMissing, mustResolvePath(t, missingDir))
+}
+
 func TestRunOrganizeForcesRunAndReturnsLogPath(t *testing.T) {
 	service := NewService(DefaultWebConfig("127.0.0.1", 0, false, "", ""))
 	inputDir, outputDir := createOrganizeFixture(t)
@@ -97,6 +112,19 @@ func createOrganizeFixture(t *testing.T) (string, string) {
 	return inputDir, outputDir
 }
 
+func createOrganizeFixtureWithMissingMetadata(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	inputDir, outputDir := createOrganizeFixture(t)
+	missingDir := filepath.Join(inputDir, "missing_metadata")
+	if err := os.MkdirAll(missingDir, 0o755); err != nil {
+		t.Fatalf("create missing metadata dir: %v", err)
+	}
+	writeFile(t, filepath.Join(missingDir, "orphan.mp3"), "fake audio")
+
+	return inputDir, outputDir, missingDir
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
@@ -118,4 +146,23 @@ func assertFileNotExists(t *testing.T, path string) {
 	} else if !os.IsNotExist(err) {
 		t.Fatalf("stat %s: %v", path, err)
 	}
+}
+
+func assertStringSliceContains(t *testing.T, values []string, want string) {
+	t.Helper()
+	for _, value := range values {
+		if value == want {
+			return
+		}
+	}
+	t.Fatalf("expected %q in %v", want, values)
+}
+
+func mustResolvePath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", path, err)
+	}
+	return resolved
 }

--- a/internal/organizer/organize.go
+++ b/internal/organizer/organize.go
@@ -104,8 +104,8 @@ func (o *Organizer) shouldSkipOutputDirectory(path string) bool {
 
 // handleMissingMetadata logs directories that don't contain any usable metadata.
 func (o *Organizer) handleMissingMetadata(path string) {
+	o.summary.MetadataMissing = append(o.summary.MetadataMissing, path)
 	if o.config.Verbose {
-		o.summary.MetadataMissing = append(o.summary.MetadataMissing, path)
 		PrintYellow("⚠️  No metadata found in %s", path)
 	}
 }

--- a/web/tests/e2e/gui-smoke.spec.ts
+++ b/web/tests/e2e/gui-smoke.spec.ts
@@ -104,7 +104,7 @@ test('does not treat redacted ABS credentials as usable browser state', async ({
   await expect(page.getByText(/Saved ABS credentials are redacted/)).toBeVisible()
 })
 
-test('wires organize preview and run to backend endpoints', async ({ page }) => {
+test('contracts organize preview and run UI state with mocked backend responses', async ({ page }) => {
   let previewBody: Record<string, any> | undefined
   let runBody: Record<string, any> | undefined
 

--- a/web/tests/e2e/organize-real.spec.ts
+++ b/web/tests/e2e/organize-real.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Page } from '@playwright/test'
+import { access, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { startTestServer, type TestServer } from './server'
+
+let server: TestServer
+
+test.beforeAll(async () => {
+  server = await startTestServer()
+})
+
+test.afterAll(async () => {
+  await server?.stop()
+})
+
+test('runs organize preview and execution against real filesystem fixtures', async ({ page }) => {
+  test.setTimeout(60_000)
+
+  const fixture = await createOrganizeFixture()
+  try {
+    const organizeRequests: string[] = []
+    page.on('request', (request) => {
+      const url = new URL(request.url())
+      if (url.pathname.startsWith('/api/organize/')) {
+        organizeRequests.push(url.pathname)
+      }
+    })
+
+    await loadApp(page)
+    await page.getByRole('textbox', { name: 'Source folder' }).fill(fixture.sourceDir)
+    await page.getByRole('textbox', { name: 'Output folder' }).fill(fixture.outputDir)
+    await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+
+    await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
+    await page.getByRole('button', { name: 'Create Dry-run Preview' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Organize preview ready' })).toBeVisible()
+    await expectSummaryValue(page, 'Metadata found', '1')
+    await expectSummaryValue(page, 'Planned moves', '1')
+    await expectSummaryValue(page, 'Warnings', '2')
+    await expect(page.getByText(fixture.missingDir)).toBeVisible()
+    await expect(page.getByText(fixture.expectedDir)).toBeVisible()
+    await expect.poll(() => pathExists(fixture.expectedFile)).toBe(false)
+    expect(organizeRequests).toContain('/api/organize/preview')
+
+    await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
+    await page.getByRole('button', { name: 'Review Preview & Continue' }).click()
+    await expect(page.getByRole('heading', { name: 'Execute the reviewed plan' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Run Organize' })).toBeEnabled()
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Run Organize will change files')
+      await dialog.accept()
+    })
+    await page.getByRole('button', { name: 'Run Organize' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Organize Run Complete' })).toBeVisible()
+    await expect(page.getByText(fixture.expectedLog)).toBeVisible()
+    await expect.poll(() => pathExists(fixture.expectedFile)).toBe(true)
+    expect(organizeRequests).toContain('/api/organize/run')
+  } finally {
+    await fixture.cleanup()
+  }
+})
+
+type OrganizeFixture = {
+  sourceDir: string
+  outputDir: string
+  missingDir: string
+  expectedDir: string
+  expectedFile: string
+  expectedLog: string
+  cleanup: () => Promise<void>
+}
+
+async function createOrganizeFixture(): Promise<OrganizeFixture> {
+  const root = await mkFixtureRoot()
+  const sourceDir = join(root, 'source')
+  const outputDir = join(root, 'output')
+  const bookDir = join(sourceDir, 'fixture-book')
+  const missingDir = join(sourceDir, 'missing-metadata')
+
+  await mkdir(bookDir, { recursive: true })
+  await mkdir(missingDir, { recursive: true })
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(
+    join(bookDir, 'metadata.json'),
+    JSON.stringify({
+      title: 'Fixture Book',
+      authors: ['Fixture Author'],
+      series: ['Fixture Series #1'],
+    }),
+  )
+  await writeFile(join(bookDir, 'audio.mp3'), 'fake audio data')
+  await writeFile(join(missingDir, 'orphan.mp3'), 'fake audio data without metadata')
+
+  const expectedDir = join(outputDir, 'Fixture Author', 'Fixture Series', 'Fixture Book')
+  const resolvedOutputDir = await realpath(outputDir)
+
+  return {
+    sourceDir,
+    outputDir,
+    missingDir,
+    expectedDir,
+    expectedFile: join(expectedDir, 'audio.mp3'),
+    expectedLog: join(resolvedOutputDir, '.abook-org.log'),
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  }
+}
+
+async function mkFixtureRoot(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'abo-web-organize-'))
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function loadApp(page: Page): Promise<void> {
+  const consoleMessages: string[] = []
+  page.on('console', (message) => {
+    if (['error', 'warning'].includes(message.type())) {
+      consoleMessages.push(`${message.type()}: ${message.text()}`)
+    }
+  })
+
+  await page.goto(server.url)
+  await expect(page.locator('#app')).not.toBeEmpty()
+
+  expect(consoleMessages, 'No browser console warnings/errors during initial render').toEqual([])
+}
+
+async function expectSummaryValue(page: Page, label: string, value: string): Promise<void> {
+  await expect(
+    page.locator(
+      `.result-grid.compact >> xpath=./span[normalize-space(.)="${label}"]/following-sibling::strong[1]`,
+    ),
+  ).toHaveText(value)
+}


### PR DESCRIPTION
Resolves #80

## Summary

- Added a fixture-backed Playwright E2E spec for the Organize web workflow that creates real source/output directories, drives the browser through preview review and confirmed run, and verifies the output file plus undo log path.
- Renamed the existing mocked organize browser test so it is clearly supplemental UI-contract coverage.
- Fixed organizer summaries so missing-metadata directories are reported even when verbose console logging is disabled, allowing web previews to show real warning counts.

## Tests

- `go test ./internal/app -run 'TestPreviewOrganize|TestRunOrganize' -count=1`
- `npx playwright test tests/e2e/organize-real.spec.ts --project=chromium-desktop`
- `go test ./internal/app ./internal/organizer -count=1`
- `npx playwright test tests/e2e/organize-real.spec.ts`
- `npm run test:e2e`
- `go test ./...`
- `prek run --all-files`

## Docs / Changelog

- Added an `Unreleased` changelog entry for the warning-summary behavior.
- ABS matrix not applicable; this change covers local web Organize workflow behavior only.
