### PR TITLE
Add real rename web E2E coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frontend embed path is now stable for goreleaser by building into `internal/server/static`.
 - Release workflows build the web frontend before packaging the single binary.
 - Organize summaries now report directories missing metadata even when verbose console logging is disabled, so web previews show real warning counts.
+- Rename previews now report skipped files, extraction errors, and duplicate target conflicts in backend summaries used by the web UI.
 
 ### Changed
 

--- a/internal/app/rename_test.go
+++ b/internal/app/rename_test.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jeeftor/audiobook-organizer/internal/organizer"
+)
+
+func TestPreviewRenameReturnsRealSummaryState(t *testing.T) {
+	service := NewService(DefaultWebConfig("127.0.0.1", 0, false, "", ""))
+	inputDir := createRenameFixture(t)
+
+	resp, err := service.PreviewRename(context.Background(), RenameRequest{
+		Config: RenameConfigDTO{
+			BaseDir:      inputDir,
+			Template:     "{author} - {title}",
+			DryRun:       false,
+			AuthorFormat: "first-last",
+			Recursive:    true,
+			PreservePath: true,
+			FieldMapping: FieldMappingDTO{
+				TitleField:   "title",
+				SeriesField:  "series",
+				AuthorFields: []string{"authors"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PreviewRename() error = %v", err)
+	}
+
+	if got := len(resp.Candidates); got != 4 {
+		t.Fatalf("candidate count = %d, want 4", got)
+	}
+	if resp.Summary.FilesScanned != 4 {
+		t.Fatalf("FilesScanned = %d, want 4", resp.Summary.FilesScanned)
+	}
+	if resp.Summary.FilesSkipped != 2 {
+		t.Fatalf("FilesSkipped = %d, want 2", resp.Summary.FilesSkipped)
+	}
+	if resp.Summary.ConflictsFound != 1 {
+		t.Fatalf("ConflictsFound = %d, want 1", resp.Summary.ConflictsFound)
+	}
+	if len(resp.Summary.Errors) != 1 {
+		t.Fatalf("Errors length = %d, want 1", len(resp.Summary.Errors))
+	}
+
+	conflict := findRenameCandidate(t, resp.Candidates, "02-conflict-b")
+	if !conflict.IsConflict {
+		t.Fatal("second duplicate candidate should be marked as conflict")
+	}
+	if got := filepath.Base(conflict.ProposedPath); got != "Conflict Author - Conflict Book (2).mp3" {
+		t.Fatalf(
+			"conflict proposed filename = %q, want %q",
+			got,
+			"Conflict Author - Conflict Book (2).mp3",
+		)
+	}
+
+	noop := findRenameCandidate(t, resp.Candidates, "03-noop")
+	if !noop.IsNoOp {
+		t.Fatal("matching filename candidate should be marked as no-op")
+	}
+
+	broken := findRenameCandidate(t, resp.Candidates, "04-broken")
+	if broken.Error == "" {
+		t.Fatal("broken audio candidate should report an extraction error")
+	}
+}
+
+func createRenameFixture(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	sourceAudio := filepath.Join(
+		"..",
+		"..",
+		"testdata",
+		"mp3flat",
+		"charlesdexterward_01_lovecraft_64kb.mp3",
+	)
+	createRenameBook(t, root, "01-conflict-a", "original-a.mp3", sourceAudio, `{
+		"title": "Conflict Book",
+		"authors": ["Conflict Author"],
+		"series": ["Rename Series #1"]
+	}`)
+	createRenameBook(t, root, "02-conflict-b", "original-b.mp3", sourceAudio, `{
+		"title": "Conflict Book",
+		"authors": ["Conflict Author"],
+		"series": ["Rename Series #1"]
+	}`)
+	createRenameBook(t, root, "03-noop", "Noop Author - Noop Book.mp3", sourceAudio, `{
+		"title": "Noop Book",
+		"authors": ["Noop Author"]
+	}`)
+
+	brokenDir := filepath.Join(root, "04-broken")
+	if err := os.MkdirAll(brokenDir, 0o755); err != nil {
+		t.Fatalf("create broken dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brokenDir, "broken.mp3"), []byte("not audio"), 0o644); err != nil {
+		t.Fatalf("write broken audio: %v", err)
+	}
+
+	return root
+}
+
+func createRenameBook(t *testing.T, root, dirName, audioName, sourceAudio, metadata string) {
+	t.Helper()
+	bookDir := filepath.Join(root, dirName)
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatalf("create book dir: %v", err)
+	}
+	copyFile(t, sourceAudio, filepath.Join(bookDir, audioName))
+	if err := os.WriteFile(filepath.Join(bookDir, "metadata.json"), []byte(metadata), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func copyFile(t *testing.T, source, target string) {
+	t.Helper()
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read fixture audio: %v", err)
+	}
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		t.Fatalf("write fixture audio: %v", err)
+	}
+}
+
+func findRenameCandidate(
+	t *testing.T,
+	candidates []organizer.RenameCandidate,
+	pathPart string,
+) organizer.RenameCandidate {
+	t.Helper()
+	for _, candidate := range candidates {
+		if strings.Contains(candidate.CurrentPath, pathPart) {
+			return candidate
+		}
+	}
+	t.Fatalf("candidate containing %q not found", pathPart)
+	return organizer.RenameCandidate{}
+}

--- a/internal/organizer/renamer.go
+++ b/internal/organizer/renamer.go
@@ -192,11 +192,7 @@ func (r *Renamer) Execute() error {
 	// 2. Filter out no-ops
 	toRename := filterRenameableCandidates(candidates)
 
-	// 3. Detect conflicts
-	conflicts := detectConflicts(toRename)
-	r.summary.ConflictsFound = len(conflicts)
-
-	// 4. Execute renames
+	// 3. Execute renames
 	for _, candidate := range toRename {
 		// Skip if prompt is enabled and user declines
 		if r.config.PromptEnabled {
@@ -213,7 +209,7 @@ func (r *Renamer) Execute() error {
 		r.summary.FilesRenamed++
 	}
 
-	// 5. Save log
+	// 4. Save log
 	if !r.config.DryRun && len(r.logEntries) > 0 {
 		if err := r.SaveLog(); err != nil {
 			return err
@@ -297,8 +293,46 @@ func (r *Renamer) ScanFiles() ([]RenameCandidate, error) {
 
 		return nil
 	})
+	if err != nil {
+		return candidates, err
+	}
 
-	return candidates, err
+	r.finalizePreviewSummary(candidates)
+	return candidates, nil
+}
+
+func (r *Renamer) finalizePreviewSummary(candidates []RenameCandidate) {
+	summary := RenameSummary{
+		FilesScanned: len(candidates),
+	}
+	resolver := NewConflictResolver()
+
+	for i := range candidates {
+		if candidates[i].Error != "" {
+			summary.FilesSkipped++
+			summary.Errors = append(summary.Errors, candidates[i].Error)
+			continue
+		}
+		if candidates[i].IsNoOp {
+			summary.FilesSkipped++
+			continue
+		}
+
+		filename := filepath.Base(candidates[i].ProposedPath)
+		resolvedName, isConflict := resolver.CheckConflict(filename)
+		if !isConflict {
+			continue
+		}
+
+		candidates[i].IsConflict = true
+		candidates[i].ProposedPath = filepath.Join(
+			filepath.Dir(candidates[i].ProposedPath),
+			resolvedName,
+		)
+		summary.ConflictsFound++
+	}
+
+	r.summary = summary
 }
 
 // GenerateNewPath generates the new path for a file based on metadata

--- a/internal/organizer/renamer_test.go
+++ b/internal/organizer/renamer_test.go
@@ -256,31 +256,6 @@ func TestRenamer_Execute_DryRun(t *testing.T) {
 func TestRenamer_ConflictDetection(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create two files that would generate the same target name
-	file1 := filepath.Join(tmpDir, "file1.m4b")
-	file2 := filepath.Join(tmpDir, "file2.m4b")
-
-	if err := os.WriteFile(file1, []byte("content1"), 0o644); err != nil {
-		t.Fatalf("Failed to create file1: %v", err)
-	}
-	if err := os.WriteFile(file2, []byte("content2"), 0o644); err != nil {
-		t.Fatalf("Failed to create file2: %v", err)
-	}
-
-	// Create metadata for both (same title/author = conflict)
-	metadataContent := `{
-		"title": "Same Title",
-		"authors": ["Same Author"]
-	}`
-
-	for _, file := range []string{file1, file2} {
-		dir := filepath.Dir(file)
-		metadataPath := filepath.Join(dir, "metadata.json")
-		if err := os.WriteFile(metadataPath, []byte(metadataContent), 0o644); err != nil {
-			t.Fatalf("Failed to write metadata.json: %v", err)
-		}
-	}
-
 	config := &RenamerConfig{
 		BaseDir:      tmpDir,
 		Template:     "{author} - {title}",
@@ -293,15 +268,77 @@ func TestRenamer_ConflictDetection(t *testing.T) {
 		t.Fatalf("NewRenamer() error: %v", err)
 	}
 
-	candidates, err := renamer.ScanFiles()
+	candidates := []RenameCandidate{
+		{
+			CurrentPath:  filepath.Join(tmpDir, "file1.m4b"),
+			ProposedPath: filepath.Join(tmpDir, "Same Author - Same Title.m4b"),
+		},
+		{
+			CurrentPath:  filepath.Join(tmpDir, "file2.m4b"),
+			ProposedPath: filepath.Join(tmpDir, "Same Author - Same Title.m4b"),
+		},
+	}
+	renamer.finalizePreviewSummary(candidates)
+
+	if !candidates[1].IsConflict {
+		t.Fatal("second duplicate candidate should be marked as a conflict")
+	}
+	if got := filepath.Base(candidates[1].ProposedPath); got != "Same Author - Same Title (2).m4b" {
+		t.Fatalf(
+			"resolved conflict filename = %q, want %q",
+			got,
+			"Same Author - Same Title (2).m4b",
+		)
+	}
+	if got := renamer.GetSummary().ConflictsFound; got != 1 {
+		t.Fatalf("ConflictsFound = %d, want 1", got)
+	}
+}
+
+func TestRenamer_PreviewSummaryCountsSkippedErrorsAndConflicts(t *testing.T) {
+	tmpDir := t.TempDir()
+	renamer, err := NewRenamer(&RenamerConfig{
+		BaseDir:      tmpDir,
+		Template:     "{author} - {title}",
+		AuthorFormat: AuthorFormatFirstLast,
+	})
 	if err != nil {
-		t.Fatalf("ScanFiles() error: %v", err)
+		t.Fatalf("NewRenamer() error: %v", err)
 	}
 
-	// Check for conflicts
-	conflicts := detectConflicts(candidates)
-	if len(conflicts) == 0 {
-		t.Error("detectConflicts() should detect conflict for duplicate target names")
+	candidates := []RenameCandidate{
+		{
+			CurrentPath:  filepath.Join(tmpDir, "source-one.mp3"),
+			ProposedPath: filepath.Join(tmpDir, "Preview Author - Preview Book.mp3"),
+		},
+		{
+			CurrentPath:  filepath.Join(tmpDir, "source-two.mp3"),
+			ProposedPath: filepath.Join(tmpDir, "Preview Author - Preview Book.mp3"),
+		},
+		{
+			CurrentPath:  filepath.Join(tmpDir, "Noop Author - Noop Book.mp3"),
+			ProposedPath: filepath.Join(tmpDir, "Noop Author - Noop Book.mp3"),
+			IsNoOp:       true,
+		},
+		{
+			CurrentPath: filepath.Join(tmpDir, "broken.mp3"),
+			Error:       "Failed to extract metadata: test error",
+		},
+	}
+	renamer.finalizePreviewSummary(candidates)
+
+	summary := renamer.GetSummary()
+	if summary.FilesScanned != 4 {
+		t.Fatalf("FilesScanned = %d, want 4", summary.FilesScanned)
+	}
+	if summary.FilesSkipped != 2 {
+		t.Fatalf("FilesSkipped = %d, want 2", summary.FilesSkipped)
+	}
+	if summary.ConflictsFound != 1 {
+		t.Fatalf("ConflictsFound = %d, want 1", summary.ConflictsFound)
+	}
+	if len(summary.Errors) != 1 {
+		t.Fatalf("Errors length = %d, want 1", len(summary.Errors))
 	}
 }
 

--- a/web/tests/e2e/gui-smoke.spec.ts
+++ b/web/tests/e2e/gui-smoke.spec.ts
@@ -194,7 +194,7 @@ test('keeps organize run locked when preview fails', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
 })
 
-test('wires rename preview and keeps rename execution deferred', async ({ page }) => {
+test('contracts rename preview UI state with mocked backend responses', async ({ page }) => {
   let previewBody: Record<string, any> | undefined
   let renameRunRequested = false
 

--- a/web/tests/e2e/rename-real.spec.ts
+++ b/web/tests/e2e/rename-real.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test, type Page } from '@playwright/test'
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { startTestServer, type TestServer } from './server'
+
+let server: TestServer
+
+test.beforeAll(async () => {
+  server = await startTestServer()
+})
+
+test.afterAll(async () => {
+  await server?.stop()
+})
+
+test('creates real rename preview candidates while execution stays deferred', async ({ page }) => {
+  test.setTimeout(60_000)
+
+  const fixture = await createRenameFixture()
+  try {
+    const renameRequests: string[] = []
+    page.on('request', (request) => {
+      const url = new URL(request.url())
+      if (url.pathname.startsWith('/api/rename/')) {
+        renameRequests.push(url.pathname)
+      }
+    })
+
+    await loadApp(page)
+    await page.getByRole('button', { name: /Rename/ }).click()
+    await page.getByRole('textbox', { name: 'Source folder' }).fill(fixture.sourceDir)
+    await page.getByRole('textbox', { name: 'Rename template' }).fill('{author} - {title}')
+    await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+
+    await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
+    await page.getByRole('button', { name: 'Create Rename Preview' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Rename preview ready' })).toBeVisible()
+    await expectSummaryValue(page, 'Files scanned', '4')
+    await expectSummaryValue(page, 'Candidates', '4')
+    await expectSummaryValue(page, 'Conflicts', '1')
+    await expectSummaryValue(page, 'Skipped', '2')
+    await expectSummaryValue(page, 'Errors', '1')
+    await expect(page.getByText(fixture.firstProposedPath)).toBeVisible()
+    await expect(page.getByText(fixture.conflictProposedPath)).toBeVisible()
+    await expect(page.locator('.move-list em').filter({ hasText: /^Conflict$/ })).toBeVisible()
+    await expect(page.locator('.move-list em').filter({ hasText: 'Skipped: unchanged' })).toBeVisible()
+    await expect(page.locator('.warning-list li').filter({ hasText: /Failed to extract metadata/ })).toBeVisible()
+    expect(renameRequests).toContain('/api/rename/preview')
+
+    await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
+    await page.getByRole('button', { name: 'Review Candidates & Continue' }).click()
+    await expect(page.getByRole('heading', { name: 'Rename Execution Deferred' })).toBeVisible()
+    await expect(page.getByText(/Rename execution is deferred/)).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Rename Execution Deferred' })).toBeDisabled()
+    expect(renameRequests).not.toContain('/api/rename/run')
+  } finally {
+    await fixture.cleanup()
+  }
+})
+
+type RenameFixture = {
+  sourceDir: string
+  firstProposedPath: string
+  conflictProposedPath: string
+  cleanup: () => Promise<void>
+}
+
+async function createRenameFixture(): Promise<RenameFixture> {
+  const root = await mkdtemp(join(tmpdir(), 'abo-web-rename-'))
+  const sourceAudio = join(repoRoot(), 'testdata', 'mp3flat', 'charlesdexterward_01_lovecraft_64kb.mp3')
+  const conflictADir = join(root, '01-conflict-a')
+  const conflictBDir = join(root, '02-conflict-b')
+
+  await createRenameBook(root, '01-conflict-a', 'original-a.mp3', sourceAudio, {
+    title: 'Conflict Book',
+    authors: ['Conflict Author'],
+    series: ['Rename Series #1'],
+  })
+  await createRenameBook(root, '02-conflict-b', 'original-b.mp3', sourceAudio, {
+    title: 'Conflict Book',
+    authors: ['Conflict Author'],
+    series: ['Rename Series #1'],
+  })
+  await createRenameBook(root, '03-noop', 'Noop Author - Noop Book.mp3', sourceAudio, {
+    title: 'Noop Book',
+    authors: ['Noop Author'],
+  })
+
+  const brokenDir = join(root, '04-broken')
+  await mkdir(brokenDir, { recursive: true })
+  await writeFile(join(brokenDir, 'broken.mp3'), 'not audio')
+
+  return {
+    sourceDir: root,
+    firstProposedPath: join(conflictADir, 'Conflict Author - Conflict Book.mp3'),
+    conflictProposedPath: join(conflictBDir, 'Conflict Author - Conflict Book (2).mp3'),
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  }
+}
+
+async function createRenameBook(
+  root: string,
+  dirName: string,
+  audioName: string,
+  sourceAudio: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  const bookDir = join(root, dirName)
+  await mkdir(bookDir, { recursive: true })
+  await copyFile(sourceAudio, join(bookDir, audioName))
+  await writeFile(join(bookDir, 'metadata.json'), JSON.stringify(metadata))
+}
+
+function repoRoot(): string {
+  return new URL('../../..', import.meta.url).pathname
+}
+
+async function loadApp(page: Page): Promise<void> {
+  const consoleMessages: string[] = []
+  page.on('console', (message) => {
+    if (['error', 'warning'].includes(message.type())) {
+      consoleMessages.push(`${message.type()}: ${message.text()}`)
+    }
+  })
+
+  await page.goto(server.url)
+  await expect(page.locator('#app')).not.toBeEmpty()
+
+  expect(consoleMessages, 'No browser console warnings/errors during initial render').toEqual([])
+}
+
+async function expectSummaryValue(page: Page, label: string, value: string): Promise<void> {
+  await expect(
+    page.locator(
+      `.result-grid.compact >> xpath=./span[normalize-space(.)="${label}"]/following-sibling::strong[1]`,
+    ),
+  ).toHaveText(value)
+}


### PR DESCRIPTION
Resolves #81

## Summary

- Added a fixture-backed Playwright E2E spec for the Rename preview web workflow that creates real source files, calls the real local `/api/rename/preview` endpoint, and verifies candidates, summary counts, conflicts, no-op/skipped state, and extraction errors.
- Updated rename preview summary generation so scanned candidates report skipped files, extraction errors, and duplicate target conflicts before the web API returns.
- Renamed the existing mocked rename browser test so it is clearly supplemental UI-contract coverage.

## Tests

- `go test ./internal/app -run 'TestPreviewRename' -count=1`
- `go test ./internal/organizer -run 'TestRenamer_' -count=1`
- `npm run build`
- `npx playwright test tests/e2e/rename-real.spec.ts --project=chromium-desktop`
- `npx playwright test tests/e2e/rename-real.spec.ts`
- `go test ./internal/app ./internal/organizer -count=1`
- `npm run test:e2e`
- `go test ./...`
- `prek run --all-files`

## Docs / Changelog

- Added an `Unreleased` changelog entry for rename preview summary behavior.
- ABS matrix not applicable; this change covers local web Rename preview behavior only.
