### PR TITLE
Stabilize local web UI browser smoke tests

### DIFF
--- a/docs/GUI_TESTING.md
+++ b/docs/GUI_TESTING.md
@@ -15,6 +15,9 @@ The GUI is the local Vue web UI served by `audiobook-organizer web`. GUI tests s
 # Install frontend dependencies
 make web-install
 
+# Install Playwright-managed Chromium for browser tests
+cd web && npm run install:browsers
+
 # Run Go REST endpoint tests without Docker or a browser
 make gui-rest-test
 
@@ -32,10 +35,24 @@ Direct npm equivalents:
 
 ```bash
 cd web
+npm install
+npm run install:browsers
 npm run test:e2e
 npm run test:e2e:headed
 npm run test:e2e:ui
 ```
+
+## Browser Setup
+
+The Playwright suite is configured to run both desktop and mobile projects with Playwright-managed Chromium. Install that browser payload from `web/`:
+
+```bash
+npm run install:browsers
+```
+
+On macOS, Playwright stores the managed browser revisions under `~/Library/Caches/ms-playwright`; on Linux CI runners, it uses the matching Playwright cache directory for that operating system. The suite should launch from that managed cache after `npm install` and `npm run install:browsers`.
+
+If Playwright reports a missing executable such as `chromium_headless_shell-<rev>`, rerun `npm run install:browsers` from `web/`, then rerun `npm run test:e2e`. A separate Chrome Headless Shell under `~/.cache/puppeteer/chrome-headless-shell/` is useful for ad hoc manual rendering checks only; it is not the supported browser source for `npm run test:e2e`.
 
 ## Current Coverage
 

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --host 127.0.0.1",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview --host 127.0.0.1",
+    "install:browsers": "playwright install chromium",
     "test:e2e": "npm run build && playwright test",
     "test:e2e:headed": "npm run build && playwright test --headed",
     "test:e2e:ui": "npm run build && playwright test --ui"

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -19,11 +19,11 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium-desktop',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], browserName: 'chromium' },
     },
     {
       name: 'chromium-mobile',
-      use: { ...devices['Pixel 7'] },
+      use: { ...devices['Pixel 7'], browserName: 'chromium' },
     },
   ],
 })


### PR DESCRIPTION
Resolves #66

## Summary

- Adds `npm run install:browsers` for Playwright-managed Chromium setup.
- Configures desktop and mobile Playwright projects to explicitly use managed Chromium.
- Documents the supported browser cache/setup path and clarifies that Puppeteer Chrome Headless Shell is only for ad hoc rendering checks.

## Tests

- `npm install`
- `npm run install:browsers`
- `make web-build`
- `cd web && npm run test:e2e`
- `git diff --check`
- `prek run --all-files`

## Docs / Changelog

- Updated `docs/GUI_TESTING.md`.
- No changelog entry; this is test setup/documentation, not user-facing product behavior.

## Browser Notes

- Verified Playwright-managed Chromium at `/Users/jstein/Library/Caches/ms-playwright/chromium-1223/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`.
