### PR TITLE
Recommend next work after agent closeout

### DIFF
--- a/.agents/skills/abo-issue-closeout/SKILL.md
+++ b/.agents/skills/abo-issue-closeout/SKILL.md
@@ -23,5 +23,6 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 8. After merge, confirm the linked issue closed and the feature branch or worktree was cleaned up. Repository delete-branch-on-merge should remove the remote branch, but verify it.
 9. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
 10. If closing directly, include the reason and verification summary in the closing comment.
+11. After issue closeout, follow `references/abo-assistant/common.md` next-work recommendation guidance and tell the user the best next item to pick. Do not start the next item unless the user asks.
 
 Do not close an issue with failing or unrun required checks unless the user explicitly accepts the risk and the reason is documented.

--- a/.agents/skills/abo-pr/SKILL.md
+++ b/.agents/skills/abo-pr/SKILL.md
@@ -19,5 +19,6 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 - Issue completion checks before PR: `$abo-issue-verify`.
 - Final issue/changelog/docs hygiene: `$abo-issue-closeout`.
 - Finished feature, fix, docs, or chore branch: verify checks, get the PR ready, enable auto-merge or merge back into protected `master`, confirm the issue closed, and clean up the branch or worktree.
+- After a PR merge closes tracked work, use `references/abo-assistant/common.md` next-work recommendation guidance before ending the response. Suggest the next issue or closeout step, but do not start it without user direction.
 
 If intent is unclear, ask whether the user wants PR text, PR creation, PR status watching, or closeout verification.

--- a/.agents/skills/abo-workflow/SKILL.md
+++ b/.agents/skills/abo-workflow/SKILL.md
@@ -35,3 +35,7 @@ If they choose existing issues, inspect open issues first and help pick one befo
 - PR drafting, creation, or watching: `$abo-pr`.
 
 If intent is clear, apply the relevant specialist workflow directly in the current agent. If the user explicitly asks for subagents or parallel work, delegate bounded tasks to specialist subagents.
+
+## Closeout
+
+When a routed task completes, use `references/abo-assistant/common.md` next-work recommendation guidance before ending the response. Recommend the next issue, closeout step, or parallel-safe pairing based on the current open issue list and dependency chain, but wait for the user before starting new work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,3 +269,4 @@ Be careful when editing:
 6. Run the most relevant tests or lint target.
 7. Update docs and `CHANGELOG.md` when the change is user-visible.
 8. Summarize behavior changes and any verification gaps clearly.
+9. After tracked work is complete, recommend the next useful issue, closeout step, or parallel-safe pairing based on the current open issue list and workflow dependencies. Do not start the next item unless the user asks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refined the `abo-workflow` skill to prompt between creating new tracked work and selecting from existing GitHub issues.
 - Documented browser binary setup for local web UI E2E checks, including Playwright-managed Chromium and cached Chrome Headless Shell fallback behavior.
 - Clarified maintainer workflow guidance so user-facing workflow issues require real E2E acceptance evidence, while mocked UI/API tests remain supplemental.
+- Clarified repo-local agent closeout guidance so completed tracked work ends with a next-work recommendation based on open issues and dependency context.
 - Restructured the local web UI into explicit organize, rename, and Audiobookshelf workflow stages so configure, dry-run preview, run, and review states are separated.
 - Improved local web UI startup handling so config/options loading and fallback states are visible and Audiobookshelf metadata mode stays scoped to the ABS workflow.
 - Wired the local web UI organize workflow to real preview and run endpoints with review gating and backend result summaries.

--- a/references/abo-assistant/common.md
+++ b/references/abo-assistant/common.md
@@ -20,6 +20,19 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - PRs target `master`; prefer Squash and merge; issues normally close through PR merge.
 - Repository auto-merge and delete-branch-on-merge are enabled. When required checks are green and the PR is otherwise mergeable, enable auto-merge. If GitHub reports `REVIEW_REQUIRED`, report the branch protection mismatch instead of trying to self-approve.
 - Do not treat a local commit or draft PR as done. Finish the cycle by getting the PR ready, passing required checks, enabling or completing merge back into `master`, confirming the linked issue closed, and cleaning up the branch or worktree.
+- After tracked work is complete, suggest the next useful work item before ending the final response. Base the suggestion on current open issues, parent/child dependencies, recently completed workflow chains, and any follow-up issues created during the work. Do not start the next task unless the user asks.
+
+## Next Work Recommendation
+
+When a feature, fix, docs, test, or chore issue is finished through PR merge or explicit issue closeout:
+
+1. Inspect the remaining open issues with `gh issue list --state open --limit 30 --json number,title,updatedAt,url`.
+2. Check parent and sibling issues that were affected by the completed work, especially audit, umbrella, and matrix issues.
+3. Prefer recommendations that unblock closeout or continue the same workflow chain before switching domains.
+4. Identify parallel candidates only when their likely files and services do not overlap heavily.
+5. End with one concise recommendation and, when useful, one or two alternatives. Do not automatically create branches, issues, worktrees, or subagents for the next item without user direction.
+
+For web UI audit work, parent closeout usually comes before new implementation: close or update completed umbrella/symptom issues, then pick the next still-open child issue.
 
 ## Architecture Map
 

--- a/references/abo-assistant/pr.md
+++ b/references/abo-assistant/pr.md
@@ -48,6 +48,7 @@ Prefer enabling auto-merge once checks are green. If GitHub reports `REVIEW_REQU
 - Directly close an issue only when the user explicitly asks, the issue is obsolete/duplicate, or the work intentionally completed outside PR merge.
 - Before closeout, verify acceptance criteria against code, tests, docs, changelog, and PR state.
 - Do not close a user-facing workflow issue based only on mocked/stubbed tests. Confirm real E2E evidence or documented maintainer acceptance of the gap.
+- After closeout, use the next-work recommendation guidance in `references/abo-assistant/common.md` before ending the user-facing response. Suggest what to do next, but do not start it without user direction.
 
 ## Watcher Duties
 
@@ -56,4 +57,4 @@ Prefer enabling auto-merge once checks are green. If GitHub reports `REVIEW_REQU
 3. Apply mechanical or clearly requested fixes.
 4. Ask before risky rebases, behavior changes, or ambiguous maintainer feedback.
 5. If required checks are green and the PR is otherwise mergeable, enable auto-merge with squash/delete-branch when available.
-6. Summarize what changed, what remains blocked, and which checks should rerun.
+6. Summarize what changed, what remains blocked, which checks should rerun, and the next recommended work item when the PR closes an issue.


### PR DESCRIPTION
Resolves #92

## Summary

- Adds shared next-work recommendation guidance to the repo-local common assistant reference.
- Points PR and issue closeout skills at that shared guidance so future completed work suggests the next useful issue or closeout step.
- Adds a durable AGENTS.md workflow note and changelog entry for the maintainer workflow change.

## Tests

- `git diff --check`
- `prek run --all-files`

## Docs / Changelog

- Updated `AGENTS.md`, repo-local skills, and `references/abo-assistant/*`.
- Added `CHANGELOG.md` entry under Unreleased.

## Follow-up

- After restart, use the updated guidance to close out #64/#68 before starting #65.
