### PR TITLE
Add ABS metadata organize command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,8 @@ jobs:
             run_regex: TestRESTHarness_ABSSetupEndpoints
           - name: rest-abs-operations
             run_regex: TestRESTHarness_ABSOperationEndpoints
+          - name: abs-metadata-mode
+            run_regex: TestABSMetadataMode
     env:
       ABS_IMAGE: ghcr.io/advplyr/audiobookshelf:latest
       ABS_FIXTURE_CACHE_DIR: test/abs/.cache/staging-data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Preview-oriented app service layer**: Added an internal application service that converts web requests into organizer, renamer, and ABS operations without coupling the HTTP layer to Cobra command handling.
 - **REST execution coverage for ABS workflows**: Added Docker-backed REST tests for `metadata.json`, embedded metadata import, and flat import workflows against real Audiobookshelf containers.
 - **Flat mode ABS coverage**: Added Docker-backed flat mechanics and flat ebook import matrix coverage for Audiobookshelf workflows.
+- **ABS metadata organization**: Added `audiobook-organizer abs organize` so already-indexed Audiobookshelf items can be reorganized with ABS API metadata while reusing the normal organizer move, dry-run, undo, layout, logging, and scan follow-up flow.
 - **Text-only metadata inspection**: `audiobook-organizer metadata` now prints non-interactive metadata scan results, `metadata --json` writes machine-readable output, and `metadata-tui` keeps the old interactive metadata exploration workflow explicit.
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LDFLAGS := -ldflags "-s -w $(VERSION_FLAGS)"
 # Test packages
 UNIT_TEST_PKGS = ./...
 INTEGRATION_TEST_PKGS = $(shell go list ./... | grep -v '/integration$$')
-ABS_TEST_RUN ?= Test(ABSHarnessSmokeResetContract|MetadataJSONMode|EmbeddedAlreadyIndexed|EmbeddedMetadataImport|FlatMode(Mechanics|Import)|RESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints))
+ABS_TEST_RUN ?= Test(ABSHarnessSmokeResetContract|MetadataJSONMode|EmbeddedAlreadyIndexed|EmbeddedMetadataImport|FlatMode(Mechanics|Import)|RESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints)|ABSMetadataMode)
 ABS_REST_TEST_RUN ?= TestRESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints)
 
 .PHONY: all build clean dev dev-linux-amd64 web-install web-build web-dev gui-rest-test gui-test gui-test-headed gui-test-ui abs-dev-seed abs-dev-init abs-dev-configure abs-dev-up abs-dev-down abs-dev-reset abs-dev-reset-all abs-dev-scan abs-dev-reset-scan abs-ci-smoke abs-test-metadata abs-test-rest abs-test-matrix abs-test-e2e abs-dev-capture-baseline abs-dev-restore-baseline abs-dev-wait release test test-unit test-integration coverage coverage-html lint fmt fmt-check vet help scp-dev

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Common audiobook workflows:
 | Rename TUI | `audiobook-organizer rename-tui --dir=/books` | Interactive rename previews | Stable |
 | Metadata CLI | `audiobook-organizer metadata --dir=/books` | Text-only metadata inspection | Stable |
 | Metadata TUI | `audiobook-organizer metadata-tui --dir=/books` | Metadata inspection and template exploration | Stable |
-| Audiobookshelf CLI | `audiobook-organizer abs ...` | ABS discovery, path mapping, metadata previews, and scan triggers | Active development |
+| Audiobookshelf CLI | `audiobook-organizer abs ...` | ABS discovery, path mapping, metadata previews, ABS metadata organization, and scan triggers | Active development |
 
 ## Quick Start
 
@@ -215,6 +215,15 @@ audiobook-organizer abs scan \
   --dir=/mnt/media/audiobooks \
   --check-files
 
+# Organize already-indexed items using ABS metadata as the source of truth
+audiobook-organizer abs organize \
+  --abs-url=http://localhost:13378 \
+  --abs-token="$ABS_TOKEN" \
+  --abs-library=Audiobooks \
+  --abs-path-map="/audiobooks:/mnt/media/audiobooks" \
+  --dir=/mnt/media/audiobooks \
+  --layout=author-title
+
 # Test SQLite-backed path mapping discovery
 audiobook-organizer abs test-paths \
   --abs-sqlite=/path/to/absdatabase.sqlite \
@@ -232,7 +241,7 @@ audiobook-organizer abs websocket-test \
   --abs-token="$ABS_TOKEN"
 ```
 
-ABS metadata-driven organization is still being built out and validated through `test/abs/test-matrix.md`. For already indexed ABS libraries, prefer previewing path mappings and metadata first, then trigger an ABS scan after any filesystem move so ABS can reconcile missing and moved items.
+`abs organize` uses Audiobookshelf API metadata for already-indexed files and then sends the mapped local paths through the same organizer core used by the normal CLI. Preview with `abs scan` first when setting up path mappings. After non-dry-run moves, trigger an ABS scan so Audiobookshelf can reconcile old missing paths and newly organized paths.
 
 ## Metadata Sources
 

--- a/cmd/abs.go
+++ b/cmd/abs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -77,8 +78,22 @@ var absScanCmd = &cobra.Command{
   audiobook-organizer abs scan-trigger \
     --abs-url=http://localhost:13378 \
     --abs-token=eyJhbG... \
-    --library=main`,
+    --abs-library=main`,
 	RunE: runABSScan,
+}
+
+// absOrganizeCmd organizes already-indexed ABS items using ABS as the metadata source.
+var absOrganizeCmd = &cobra.Command{
+	Use:   "organize",
+	Short: "Organize already-indexed items using ABS metadata",
+	Example: `  audiobook-organizer abs organize \
+    --abs-url=http://localhost:13378 \
+    --abs-token=eyJhbG... \
+    --abs-library=Audiobooks \
+    --abs-path-map="/audiobooks:/mnt/media/audiobooks" \
+    --dir=/mnt/media/audiobooks \
+    --layout=author-title`,
+	RunE: runABSOrganize,
 }
 
 // absTestPathsCmd tests path discovery
@@ -106,6 +121,7 @@ var absWebSocketCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(absCmd)
 	absCmd.AddCommand(absScanCmd)
+	absCmd.AddCommand(absOrganizeCmd)
 	absCmd.AddCommand(absTestPathsCmd)
 	absCmd.AddCommand(absScanTriggerCmd)
 	absCmd.AddCommand(absWebSocketCmd)
@@ -129,6 +145,8 @@ func init() {
 	absScanCmd.Flags().
 		BoolVar(&absCheckFiles, "check-files", false, "Verify files exist on disk (slower)")
 
+	addABSOrganizeFlags()
+
 	// Header flags (for Cloudflare/proxy auth)
 	absCmd.PersistentFlags().
 		StringVar(&absHeaderFile, "header-file", "", "File with custom headers (KEY=VALUE format, one per line)")
@@ -140,6 +158,21 @@ func init() {
 	viper.BindPFlag("abs.token", absCmd.PersistentFlags().Lookup("abs-token"))
 	viper.BindPFlag("abs.library", absCmd.PersistentFlags().Lookup("abs-library"))
 	viper.BindPFlag("abs.sqlite", absCmd.PersistentFlags().Lookup("abs-sqlite"))
+}
+
+func addABSOrganizeFlags() {
+	absOrganizeCmd.Flags().
+		BoolVar(&absAllLibraries, "abs-all-libraries", false, "Organize all libraries instead of just one (requires path mappings)")
+	absOrganizeCmd.Flags().
+		StringVar(&replaceSpace, "replace_space", "", "Character to replace spaces")
+	absOrganizeCmd.Flags().
+		BoolVar(&undo, "undo", false, "Restore files to their original locations")
+	absOrganizeCmd.Flags().
+		BoolVar(&prompt, "prompt", false, "Prompt for confirmation before moving each book")
+	absOrganizeCmd.Flags().
+		BoolVar(&removeEmpty, removeEmptyKey, false, "Remove empty directories after moving files")
+	absOrganizeCmd.Flags().
+		StringVarP(&layout, "layout", "l", "author-series-title", "Directory structure layout:\n  - author-series-title:        Author/Series/Title/ (default)\n  - author-series-title-number: Author/Series/#1 - Title/ (include series number in title)\n  - author-title:               Author/Title/ (ignore series)\n  - author-only:                Author/ (flatten all books)")
 }
 
 func runABSScan(cmd *cobra.Command, args []string) error {
@@ -158,25 +191,32 @@ func runABSScan(cmd *cobra.Command, args []string) error {
 		return runDiscoveryMode(absURL, absToken, verbose)
 	}
 
-	// Auto-detect library if not specified, or resolve by name
-	if absLibraryID == "" || absLibraryID == "main" {
-		selectedLib, err := selectLibrary(absURL, absToken, "")
-		if err != nil {
-			return err
+	// Auto-detect library if not specified, or resolve by name. All-libraries
+	// mode deliberately skips single-library selection.
+	if !absAllLibraries {
+		if absLibraryID == "" || absLibraryID == "main" {
+			selectedLib, err := selectLibrary(absURL, absToken, "")
+			if err != nil {
+				return err
+			}
+			absLibraryID = selectedLib
+		} else {
+			// User provided a library - try to resolve it (could be UUID or name)
+			resolvedLib, err := selectLibrary(absURL, absToken, absLibraryID)
+			if err != nil {
+				return err
+			}
+			absLibraryID = resolvedLib
 		}
-		absLibraryID = selectedLib
-	} else {
-		// User provided a library - try to resolve it (could be UUID or name)
-		resolvedLib, err := selectLibrary(absURL, absToken, absLibraryID)
-		if err != nil {
-			return err
-		}
-		absLibraryID = resolvedLib
 	}
 
 	if verbose {
 		fmt.Printf("📡 Using API: %s\n", absURL)
-		fmt.Printf("📚 Library: %s\n", absLibraryID)
+		if absAllLibraries {
+			fmt.Printf("📚 Library: all\n")
+		} else {
+			fmt.Printf("📚 Library: %s\n", absLibraryID)
+		}
 		fmt.Printf("📁 Input dir: %s\n", inputDir)
 	}
 
@@ -326,20 +366,370 @@ func runABSScan(cmd *cobra.Command, args []string) error {
 	}
 
 	// Note about organization
-	fmt.Println("\nNote: Full organization integration coming in next update.")
-	fmt.Println("For now, use this command to verify ABS connectivity and metadata.")
+	fmt.Println(
+		"\nTo execute these moves with ABS metadata, use `audiobook-organizer abs organize`.",
+	)
 
 	// If output dir specified and not dry run, trigger library scan at end
 	if outputDir != "" && !dryRun {
 		fmt.Println("\nTo trigger ABS library scan after organizing:")
 		fmt.Printf(
-			"  audiobook-organizer abs scan-trigger --abs-url=%s --abs-token=*** --library=%s\n",
+			"  audiobook-organizer abs scan-trigger --abs-url=%s --abs-token=*** --abs-library=%s\n",
 			absURL,
 			absLibraryID,
 		)
 	}
 
 	return nil
+}
+
+func runABSOrganize(cmd *cobra.Command, args []string) error {
+	config, err := organizerConfigFromABSCommand(cmd)
+	if err != nil {
+		return err
+	}
+
+	org, err := organizer.NewOrganizer(&config)
+	if err != nil {
+		return err
+	}
+
+	if config.Undo {
+		return org.Execute()
+	}
+
+	if err := validateABSConnectionFlags(); err != nil {
+		return err
+	}
+
+	organizer.PrintBlue("🔍 Resolving paths...")
+	if err := org.ResolvePaths(); err != nil {
+		return err
+	}
+
+	provider, selectedLibraryID, err := newABSMetadataProvider(org.BaseDir())
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("📡 Loading ABS metadata...")
+	if err := provider.LoadAllItems(); err != nil {
+		return fmt.Errorf("loading ABS items: %w", err)
+	}
+	items, err := provider.GetAllItems()
+	if err != nil {
+		return fmt.Errorf("getting ABS metadata: %w", err)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].SourcePath < items[j].SourcePath
+	})
+
+	startTime := time.Now()
+	fmt.Println("📚 Organizing with ABS metadata...")
+	processed := 0
+	for _, item := range items {
+		sourcePath := item.SourcePath
+		if sourcePath == "" || !isPathWithin(org.BaseDir(), sourcePath) {
+			continue
+		}
+		if err := org.OrganizePathWithMetadata(sourcePath, item); err != nil {
+			if config.SkipErrors {
+				organizer.PrintYellow("⏩ Skipping %s: %v", sourcePath, err)
+				continue
+			}
+			return fmt.Errorf("organizing ABS item %s: %w", sourcePath, err)
+		}
+		processed++
+	}
+
+	if processed == 0 {
+		return fmt.Errorf("no mapped ABS items found under --dir %s", org.BaseDir())
+	}
+
+	if err := org.Finish(startTime); err != nil {
+		return err
+	}
+
+	if !config.DryRun {
+		organizer.PrintCyan("\n📝 Log file location: %s", org.GetLogPath())
+		if selectedLibraryID != "" {
+			organizer.PrintCyan("To update ABS after these changes, run:")
+			organizer.PrintBase(
+				"  audiobook-organizer abs scan-trigger --abs-url=%s --abs-token=*** --abs-library=%s",
+				absURL,
+				selectedLibraryID,
+			)
+		}
+	}
+	return nil
+}
+
+func organizerConfigFromABSCommand(cmd *cobra.Command) (organizer.OrganizerConfig, error) {
+	inputDir, err := inputDirFromCommand(cmd)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	outputDir, err := outputDirFromCommand(cmd)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	authorFieldsList := []string{}
+	authorFieldsValue, err := stringFlagOrViper(cmd, authorFieldsKey)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	if authorFieldsValue != "" {
+		authorFieldsList = strings.Split(authorFieldsValue, ",")
+	}
+
+	flatValue, err := boolFlagOrViper(cmd, "flat")
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	useEmbeddedValue, err := boolFlagOrViper(cmd, useEmbeddedMetaKey)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	if flatValue {
+		useEmbeddedValue = true
+	}
+
+	replaceSpaceValue, err := stringFlagOrViper(cmd, "replace_space")
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	verboseValue, err := boolFlagOrViper(cmd, "verbose")
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	dryRunValue, err := boolFlagOrViper(cmd, dryRunKey)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	undoValue, err := boolFlagOrViper(cmd, "undo")
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	promptValue, err := boolFlagOrViper(cmd, "prompt")
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	removeEmptyValue, err := boolFlagOrViper(cmd, removeEmptyKey)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	skipErrorsValue, err := boolFlagOrViper(cmd, "skip-errors")
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	layoutValue, err := stringFlagOrViper(cmd, "layout")
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	titleFieldValue, err := stringFlagOrViper(cmd, titleFieldKey)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	seriesFieldValue, err := stringFlagOrViper(cmd, seriesFieldKey)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	trackFieldValue, err := stringFlagOrViper(cmd, trackFieldKey)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+	discFieldValue, err := stringFlagOrViper(cmd, discFieldKey)
+	if err != nil {
+		return organizer.OrganizerConfig{}, err
+	}
+
+	return organizer.OrganizerConfig{
+		BaseDir:             inputDir,
+		OutputDir:           outputDir,
+		ReplaceSpace:        replaceSpaceValue,
+		Verbose:             verboseValue,
+		DryRun:              dryRunValue,
+		Undo:                undoValue,
+		Prompt:              promptValue,
+		RemoveEmpty:         removeEmptyValue,
+		UseEmbeddedMetadata: useEmbeddedValue,
+		Flat:                flatValue,
+		SkipErrors:          skipErrorsValue,
+		Layout:              layoutValue,
+		FieldMapping: organizer.FieldMapping{
+			TitleField:   titleFieldValue,
+			SeriesField:  seriesFieldValue,
+			AuthorFields: authorFieldsList,
+			TrackField:   trackFieldValue,
+			DiscField:    discFieldValue,
+		},
+	}, nil
+}
+
+func inputDirFromCommand(cmd *cobra.Command) (string, error) {
+	inputChanged := commandFlagChanged(cmd, "input")
+	dirChanged := commandFlagChanged(cmd, "dir")
+	if inputChanged {
+		return commandStringFlag(cmd, "input")
+	}
+	if dirChanged {
+		return commandStringFlag(cmd, "dir")
+	}
+	if dir := viper.GetString("dir"); dir != "" {
+		return dir, nil
+	}
+	return viper.GetString("input"), nil
+}
+
+func outputDirFromCommand(cmd *cobra.Command) (string, error) {
+	outputChanged := commandFlagChanged(cmd, "output")
+	outChanged := commandFlagChanged(cmd, "out")
+	if outputChanged {
+		return commandStringFlag(cmd, "output")
+	}
+	if outChanged {
+		return commandStringFlag(cmd, "out")
+	}
+	if out := viper.GetString("out"); out != "" {
+		return out, nil
+	}
+	return viper.GetString("output"), nil
+}
+
+func stringFlagOrViper(cmd *cobra.Command, name string) (string, error) {
+	if commandFlagChanged(cmd, name) {
+		return commandStringFlag(cmd, name)
+	}
+	return viper.GetString(name), nil
+}
+
+func boolFlagOrViper(cmd *cobra.Command, name string) (bool, error) {
+	if commandFlagChanged(cmd, name) {
+		return commandBoolFlag(cmd, name)
+	}
+	return viper.GetBool(name), nil
+}
+
+func commandFlagChanged(cmd *cobra.Command, name string) bool {
+	if flag := cmd.Flags().Lookup(name); flag != nil {
+		return flag.Changed
+	}
+	if flag := cmd.InheritedFlags().Lookup(name); flag != nil {
+		return flag.Changed
+	}
+	return false
+}
+
+func commandStringFlag(cmd *cobra.Command, name string) (string, error) {
+	if flag := cmd.Flags().Lookup(name); flag != nil {
+		return cmd.Flags().GetString(name)
+	}
+	return cmd.InheritedFlags().GetString(name)
+}
+
+func commandBoolFlag(cmd *cobra.Command, name string) (bool, error) {
+	if flag := cmd.Flags().Lookup(name); flag != nil {
+		return cmd.Flags().GetBool(name)
+	}
+	return cmd.InheritedFlags().GetBool(name)
+}
+
+func validateABSConnectionFlags() error {
+	if absURL == "" {
+		return fmt.Errorf("--abs-url is required")
+	}
+	if absToken == "" {
+		return fmt.Errorf("--abs-token is required")
+	}
+	return nil
+}
+
+func newABSMetadataProvider(inputDir string) (*abs.MetadataProvider, string, error) {
+	if absAllLibraries {
+		if len(absPathMaps) == 0 {
+			return nil, "", fmt.Errorf(
+				"--abs-all-libraries requires --abs-path-map (need path mappings to match books to libraries)",
+			)
+		}
+		mappings, err := parseABSPathMappings()
+		if err != nil {
+			return nil, "", err
+		}
+		provider := abs.NewMetadataProviderAllLibraries(absURL, absToken, mappings)
+		provider.SetClient(createABSClient(absURL, absToken))
+		return provider, "", nil
+	}
+
+	selectedLibraryID := absLibraryID
+	if selectedLibraryID == "" || selectedLibraryID == "main" {
+		var err error
+		selectedLibraryID, err = selectLibrary(absURL, absToken, "")
+		if err != nil {
+			return nil, "", err
+		}
+	} else {
+		resolvedLibraryID, err := selectLibrary(absURL, absToken, selectedLibraryID)
+		if err != nil {
+			return nil, "", err
+		}
+		selectedLibraryID = resolvedLibraryID
+	}
+
+	var provider *abs.MetadataProvider
+	var err error
+	switch {
+	case absSQLite != "":
+		provider, err = abs.NewMetadataProviderWithSQLite(
+			absURL,
+			absToken,
+			selectedLibraryID,
+			absSQLite,
+			inputDir,
+		)
+		if err != nil {
+			return nil, "", fmt.Errorf(
+				"path discovery failed: %w\n\nHint: Use --abs-path-map for manual mode",
+				err,
+			)
+		}
+	case len(absPathMaps) > 0:
+		mappings, err := parseABSPathMappings()
+		if err != nil {
+			return nil, "", err
+		}
+		provider = abs.NewMetadataProvider(absURL, absToken, selectedLibraryID, mappings)
+	default:
+		mappings, err := autoDetectPathMappings(absURL, absToken, selectedLibraryID, inputDir)
+		if err != nil {
+			return nil, "", fmt.Errorf(
+				"auto-detection failed: %w\n\nPlease provide --abs-path-map manually",
+				err,
+			)
+		}
+		provider = abs.NewMetadataProvider(absURL, absToken, selectedLibraryID, mappings)
+	}
+	provider.SetClient(createABSClient(absURL, absToken))
+	return provider, selectedLibraryID, nil
+}
+
+func parseABSPathMappings() ([]abs.PathMapping, error) {
+	var mappings []abs.PathMapping
+	for _, rawMapping := range absPathMaps {
+		mapping, err := abs.ParsePathMapping(rawMapping)
+		if err != nil {
+			return nil, err
+		}
+		mappings = append(mappings, mapping)
+	}
+	return mappings, nil
+}
+
+func isPathWithin(basePath string, candidatePath string) bool {
+	rel, err := filepath.Rel(basePath, candidatePath)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func runABSTestPaths(cmd *cobra.Command, args []string) error {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -755,6 +755,7 @@ The CLI includes commands for integrating with [Audiobookshelf](https://www.audi
 
 ABS integration provides:
 - **Metadata scanning** - Compare local files against ABS library metadata
+- **ABS metadata organization** - Reorganize already-indexed ABS items using ABS as the metadata source
 - **Library scanning** - Trigger ABS library scans after file operations
 - **Real-time events** - WebSocket connection for scan status monitoring
 - **Custom headers** - Support for Cloudflare Access and other proxy authentication
@@ -791,6 +792,40 @@ audiobook-organizer abs scan --check-files
 - ✓ Files in correct location
 - 🚚 Files need to be moved
 - ✗ Files missing from disk
+
+#### `abs organize` - Organize With ABS Metadata
+
+Organize items that Audiobookshelf already indexed. ABS supplies the metadata and
+path mapping, then Audiobook Organizer reuses the normal organizer move, dry-run,
+undo, layout, logging, and prompt behavior.
+
+```bash
+# Preview moves without changing files
+audiobook-organizer abs organize \
+  --abs-url=http://localhost:13378 \
+  --abs-token=eyJhbG... \
+  --abs-library=Audiobooks \
+  --abs-path-map="/audiobooks:/mnt/audiobooks" \
+  --dir=/mnt/audiobooks \
+  --layout=author-title \
+  --dry-run
+
+# Move files in place using ABS metadata
+audiobook-organizer abs organize \
+  --abs-url=http://localhost:13378 \
+  --abs-token=eyJhbG... \
+  --abs-library=Audiobooks \
+  --abs-path-map="/audiobooks:/mnt/audiobooks" \
+  --dir=/mnt/audiobooks \
+  --layout=author-title
+
+# Undo the previous ABS metadata organization run
+audiobook-organizer abs organize --dir=/mnt/audiobooks --undo
+```
+
+After non-dry-run moves, run `abs scan-trigger` for the touched ABS library so
+Audiobookshelf can mark old paths missing, discover the organized paths, and then
+clean up missing rows through your normal ABS workflow.
 
 #### `abs scan-trigger` - Trigger Library Scan
 
@@ -884,6 +919,7 @@ audiobook-organizer abs scan \
 | `--header` | Custom header inline (can be used multiple times) |
 | `--all` | Show all items, not just mismatches (scan command) |
 | `--check-files` | Verify local files exist (scan command) |
+| `--abs-all-libraries` | Scan or organize all libraries with explicit path mappings |
 
 ### Getting ABS Token
 

--- a/internal/abs/client.go
+++ b/internal/abs/client.go
@@ -4,6 +4,7 @@
 package abs
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -198,6 +199,22 @@ func (c *Client) GetLibraryItem(itemID string) (*LibraryItem, error) {
 	}
 
 	return &item, nil
+}
+
+// UpdateLibraryItemMedia updates a library item's media payload.
+func (c *Client) UpdateLibraryItemMedia(itemID string, payload map[string]interface{}) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encoding media update: %w", err)
+	}
+
+	path := fmt.Sprintf("/api/items/%s/media", itemID)
+	resp, err := c.request("PATCH", path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
 }
 
 // ScanLibrary triggers a library scan

--- a/internal/abs/models.go
+++ b/internal/abs/models.go
@@ -33,22 +33,24 @@ type LibraryItemsResponse struct {
 
 // LibraryItem represents an audiobook/podcast in ABS
 type LibraryItem struct {
-	ID           string        `json:"id"`
-	LibraryID    string        `json:"libraryId"`
-	FolderID     string        `json:"folderId"`
-	Path         string        `json:"path"` // Full path to the audiobook folder
-	RelPath      string        `json:"relPath"`
-	IsFile       bool          `json:"isFile"`
-	MtimeMs      int64         `json:"mtimeMs"`
-	CTimeMs      int64         `json:"ctimeMs"`
-	BirthtimeMs  int64         `json:"birthtimeMs"`
-	AddedAt      int64         `json:"addedAt"`
-	UpdatedAt    int64         `json:"updatedAt"`
-	IsMissing    bool          `json:"isMissing"`
-	IsInvalid    bool          `json:"isInvalid"`
-	MediaType    string        `json:"mediaType"`
-	Media        Media         `json:"media"`
-	LibraryFiles []LibraryFile `json:"libraryFiles,omitempty"`
+	ID                   string        `json:"id"`
+	LibraryID            string        `json:"libraryId"`
+	FolderID             string        `json:"folderId"`
+	Path                 string        `json:"path"` // Full path to the audiobook folder
+	RelPath              string        `json:"relPath"`
+	IsFile               bool          `json:"isFile"`
+	MtimeMs              int64         `json:"mtimeMs"`
+	CTimeMs              int64         `json:"ctimeMs"`
+	BirthtimeMs          int64         `json:"birthtimeMs"`
+	AddedAt              int64         `json:"addedAt"`
+	UpdatedAt            int64         `json:"updatedAt"`
+	IsMissing            bool          `json:"isMissing"`
+	IsInvalid            bool          `json:"isInvalid"`
+	MediaType            string        `json:"mediaType"`
+	Media                Media         `json:"media"`
+	AuthorNamesFirstLast string        `json:"authorNamesFirstLast,omitempty"`
+	AuthorNamesLastFirst string        `json:"authorNamesLastFirst,omitempty"`
+	LibraryFiles         []LibraryFile `json:"libraryFiles,omitempty"`
 }
 
 // Media contains the book/podcast metadata

--- a/internal/abs/provider.go
+++ b/internal/abs/provider.go
@@ -190,6 +190,12 @@ func (p *MetadataProvider) convertToOrganizerMetadata(item *LibraryItem) organiz
 	if len(meta.Authors) == 0 && absMedia.AuthorName != "" {
 		meta.Authors = append(meta.Authors, absMedia.AuthorName)
 	}
+	if len(meta.Authors) == 0 && item.AuthorNamesFirstLast != "" {
+		meta.Authors = append(meta.Authors, splitABSNames(item.AuthorNamesFirstLast)...)
+	}
+	if len(meta.Authors) == 0 && item.AuthorNamesLastFirst != "" {
+		meta.Authors = append(meta.Authors, splitABSNames(item.AuthorNamesLastFirst)...)
+	}
 
 	// Series
 	for _, series := range absMedia.Series {
@@ -199,6 +205,11 @@ func (p *MetadataProvider) convertToOrganizerMetadata(item *LibraryItem) organiz
 	}
 
 	// Store ABS-specific data in RawData for advanced use
+	meta.RawData["title"] = meta.Title
+	meta.RawData["authors"] = strings.Join(meta.Authors, ", ")
+	meta.RawData["series"] = strings.Join(meta.Series, ", ")
+	meta.RawData["authorNamesFirstLast"] = item.AuthorNamesFirstLast
+	meta.RawData["authorNamesLastFirst"] = item.AuthorNamesLastFirst
 	meta.RawData["abs_item_id"] = item.ID
 	meta.RawData["abs_library_id"] = item.LibraryID
 	meta.RawData["abs_path"] = item.Path // Original ABS path before mapping
@@ -228,6 +239,17 @@ func (p *MetadataProvider) GetAllItems() ([]organizer.Metadata, error) {
 	}
 
 	return results, nil
+}
+
+func splitABSNames(value string) []string {
+	var names []string
+	for _, name := range strings.Split(value, ",") {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // ScanLibrary triggers an ABS library scan

--- a/internal/abs/provider_test.go
+++ b/internal/abs/provider_test.go
@@ -163,6 +163,35 @@ func TestMetadataProvider_GetMetadata(t *testing.T) {
 	}
 }
 
+func TestMetadataProvider_UsesLibraryItemAuthorNamesFallback(t *testing.T) {
+	provider := NewMetadataProvider(
+		"http://example.invalid",
+		"test-token",
+		"lib_main",
+		[]PathMapping{{ABSPrefix: "/books", LocalPrefix: "/mnt/books"}},
+	)
+
+	meta := provider.convertToOrganizerMetadata(&LibraryItem{
+		ID:                   "li_001",
+		LibraryID:            "lib_main",
+		Path:                 "/books/messy/pride",
+		AuthorNamesFirstLast: "Jane Austen",
+		Media: Media{
+			Metadata: Metadata{Title: "Pride and Prejudice"},
+		},
+	})
+
+	if len(meta.Authors) != 1 || meta.Authors[0] != "Jane Austen" {
+		t.Fatalf("Expected author fallback from library item, got %v", meta.Authors)
+	}
+	if meta.RawData["authors"] != "Jane Austen" {
+		t.Fatalf(
+			"Expected authors raw field to support field mapping, got %v",
+			meta.RawData["authors"],
+		)
+	}
+}
+
 func TestMetadataProvider_PathMappings(t *testing.T) {
 	server := mockProviderServer()
 	defer server.Close()

--- a/internal/organizer/organize.go
+++ b/internal/organizer/organize.go
@@ -465,6 +465,35 @@ func (o *Organizer) OrganizeSingleFile(filePath string, provider MetadataProvide
 	return o.executeSingleFileMove(filePath, targetPath, metadata)
 }
 
+// StaticMetadataProvider returns caller-supplied metadata for a known source path.
+type StaticMetadataProvider struct {
+	metadata Metadata
+}
+
+// NewStaticMetadataProvider creates a metadata provider from already-loaded metadata.
+func NewStaticMetadataProvider(metadata Metadata) *StaticMetadataProvider {
+	return &StaticMetadataProvider{metadata: metadata}
+}
+
+// GetMetadata returns the static metadata.
+func (p *StaticMetadataProvider) GetMetadata() (Metadata, error) {
+	return p.metadata, nil
+}
+
+// OrganizePathWithMetadata organizes a known file or directory using caller-supplied metadata.
+func (o *Organizer) OrganizePathWithMetadata(sourcePath string, metadata Metadata) error {
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("error checking source path: %w", err)
+	}
+
+	provider := NewStaticMetadataProvider(metadata)
+	if info.IsDir() {
+		return o.OrganizeAudiobook(sourcePath, provider)
+	}
+	return o.OrganizeSingleFile(sourcePath, provider)
+}
+
 // calculateSingleFileTargetPath determines the complete target path for a single file
 // including both directory and filename components.
 func (o *Organizer) calculateSingleFileTargetPath(filePath string, metadata Metadata) string {

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -298,15 +298,18 @@ func (o *Organizer) GetLogPath() string {
 	return filepath.Join(logBase, LogFileName)
 }
 
+// BaseDir returns the resolved base directory currently used by the organizer.
+func (o *Organizer) BaseDir() string {
+	return o.config.BaseDir
+}
+
 // GetSummary returns the current operation summary
 func (o *Organizer) GetSummary() Summary {
 	return o.summary
 }
 
-// Execute runs the main organization process
-func (o *Organizer) Execute() error {
-	// Clean and resolve the paths to absolute, symlink-free paths.
-	color.Blue("🔍 Resolving paths...")
+// ResolvePaths cleans and resolves configured paths to absolute, symlink-free paths.
+func (o *Organizer) ResolvePaths() error {
 	cleanBase := filepath.Clean(o.config.BaseDir)
 	absBase, err := filepath.Abs(cleanBase)
 	if err != nil {
@@ -343,6 +346,35 @@ func (o *Organizer) Execute() error {
 			return fmt.Errorf("error resolving allowed source path %s: %v", p, err)
 		}
 		o.config.AllowedSourcePaths[i] = resolved
+	}
+
+	return nil
+}
+
+// Finish writes pending logs, removes configured empty directories, and prints the summary.
+func (o *Organizer) Finish(startTime time.Time) error {
+	if !o.config.DryRun && len(o.logEntries) > 0 {
+		color.Blue("💾 Saving operation log...")
+		if err := o.saveLog(); err != nil {
+			return fmt.Errorf("error saving log: %v", err)
+		}
+	}
+
+	// Remove empty directories after all moves are complete
+	if err := o.removeEmptySourceDirs(); err != nil {
+		color.Red("❌ Error removing empty directories: %v", err)
+	}
+
+	o.printSummary(startTime)
+	return nil
+}
+
+// Execute runs the main organization process
+func (o *Organizer) Execute() error {
+	// Clean and resolve the paths to absolute, symlink-free paths.
+	color.Blue("🔍 Resolving paths...")
+	if err := o.ResolvePaths(); err != nil {
+		return err
 	}
 
 	// Check if the base path is a file rather than a directory
@@ -382,20 +414,7 @@ func (o *Organizer) Execute() error {
 		return fmt.Errorf("error walking directory: %v", err)
 	}
 
-	if !o.config.DryRun && len(o.logEntries) > 0 {
-		color.Blue("💾 Saving operation log...")
-		if err := o.saveLog(); err != nil {
-			return fmt.Errorf("error saving log: %v", err)
-		}
-	}
-
-	// Remove empty directories after all moves are complete
-	if err := o.removeEmptySourceDirs(); err != nil {
-		color.Red("❌ Error removing empty directories: %v", err)
-	}
-
-	o.printSummary(startTime)
-	return nil
+	return o.Finish(startTime)
 }
 
 // isEmptyDir checks if a directory is empty

--- a/test/abs/e2e/abs_metadata_mode_test.go
+++ b/test/abs/e2e/abs_metadata_mode_test.go
@@ -1,0 +1,371 @@
+//go:build abs_e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+type absMetadataOrganizeCase struct {
+	name          string
+	library       absLibrary
+	inputParts    []string
+	oldFiles      [][]string
+	newFiles      [][]string
+	logFile       []string
+	oldAPIPaths   []string
+	newAPIPaths   []string
+	expectedCount int
+	seedAuthors   map[string]string
+}
+
+func TestABSMetadataMode_PreviewAndScanTrigger(t *testing.T) {
+	var audioCtx absScenarioContext
+	var booksCtx absScenarioContext
+
+	step(t, "01 reset and initial ABS scan", func(t *testing.T) {
+		resetAndInitialScan(t)
+		audioCtx = newABSScenarioContext(t, plainInstance, audiobooksLibrary)
+		booksCtx = newABSScenarioContext(t, plainInstance, booksLibrary)
+	})
+
+	step(t, "02 discovery lists both libraries", func(t *testing.T) {
+		output := runOrganizer(
+			t,
+			"abs", "scan",
+			"--abs-url", os.Getenv(plainInstance.envURL),
+			"--abs-token", os.Getenv("ABS_TOKEN"),
+		)
+		assertOutputContains(
+			t,
+			output,
+			"ABS Discovery Mode",
+			"Found 2 libraries",
+			"Audiobooks",
+			"Ebooks",
+		)
+	})
+
+	step(t, "03 manual mapping preview loads audiobook metadata", func(t *testing.T) {
+		output := runOrganizer(
+			t,
+			"abs", "scan",
+			"--abs-url", os.Getenv(plainInstance.envURL),
+			"--abs-token", os.Getenv("ABS_TOKEN"),
+			"--abs-library", audiobooksLibrary.name,
+			"--abs-path-map", pathMap(audiobooksLibrary, plainInstance),
+			"--dir", localLibraryPath(plainInstance, audiobooksLibrary),
+			"--check-files",
+		)
+		assertOutputContains(
+			t,
+			output,
+			"Using API-only mode",
+			"Found 2 items",
+			"Charles Dickens",
+			"Lewis Carroll",
+		)
+	})
+
+	step(t, "04 all libraries preview loads both mappings", func(t *testing.T) {
+		output := runOrganizer(
+			t,
+			"abs", "scan",
+			"--abs-url", os.Getenv(plainInstance.envURL),
+			"--abs-token", os.Getenv("ABS_TOKEN"),
+			"--abs-all-libraries",
+			"--abs-path-map", pathMap(audiobooksLibrary, plainInstance),
+			"--abs-path-map", pathMap(booksLibrary, plainInstance),
+			"--dir", pathFromRoot("test", "abs", "runtime", "plain"),
+			"--check-files",
+		)
+		assertOutputContains(
+			t,
+			output,
+			"Using ALL LIBRARIES mode",
+			"Found 5 items",
+			"Items by library",
+		)
+	})
+
+	step(t, "05 scan trigger accepts resolved library id", func(t *testing.T) {
+		output := runOrganizer(
+			t,
+			"abs", "scan-trigger",
+			"--abs-url", os.Getenv(plainInstance.envURL),
+			"--abs-token", os.Getenv("ABS_TOKEN"),
+			"--abs-library", audioCtx.libraryID,
+		)
+		assertOutputContains(t, output, "Library scan triggered successfully")
+		waitForABSState(t, audioCtx, absStateExpectation{
+			expectedCount:  2,
+			missingCount:   0,
+			activeContains: []string{"/audiobooks/loose", "/audiobooks/unsorted-audio"},
+		})
+		waitForABSState(t, booksCtx, absStateExpectation{
+			expectedCount:  3,
+			missingCount:   0,
+			activeContains: []string{"/books/imported", "/books/random", "/books/to-sort"},
+		})
+	})
+}
+
+func TestABSMetadataMode_OrganizeAudiobooksLifecycle(t *testing.T) {
+	runABSMetadataOrganizeLifecycle(t, absMetadataAudiobookCase())
+}
+
+func TestABSMetadataMode_OrganizeBooksLifecycle(t *testing.T) {
+	runABSMetadataOrganizeLifecycle(t, absMetadataBookCase())
+}
+
+func absMetadataAudiobookCase() absMetadataOrganizeCase {
+	return absMetadataOrganizeCase{
+		name:    "plain_audiobooks_move_using_abs_metadata",
+		library: audiobooksLibrary,
+		inputParts: []string{
+			"test", "abs", "runtime", "plain", "audiobooks",
+		},
+		oldFiles: [][]string{
+			{
+				"test",
+				"abs",
+				"runtime",
+				"plain",
+				"audiobooks",
+				"unsorted-audio",
+				"drop-001",
+				"not-alice.m4b",
+			},
+			{"test", "abs", "runtime", "plain", "audiobooks", "loose", "holiday_story_final.m4b"},
+		},
+		newFiles: [][]string{
+			{
+				"test",
+				"abs",
+				"runtime",
+				"plain",
+				"audiobooks",
+				"Charles Dickens",
+				"A Christmas Carol_ A Ghost Story of Christmas",
+				"holiday_story_final.m4b",
+			},
+			{
+				"test",
+				"abs",
+				"runtime",
+				"plain",
+				"audiobooks",
+				"Lewis Carroll",
+				"Alice's Adventures in Wonderland Version 2",
+				"not-alice.m4b",
+			},
+		},
+		logFile: []string{
+			"test", "abs", "runtime", "plain", "audiobooks", ".abook-org.log",
+		},
+		oldAPIPaths: []string{
+			"/audiobooks/loose",
+			"/audiobooks/unsorted-audio",
+		},
+		newAPIPaths: []string{
+			"/audiobooks/Charles Dickens/A Christmas Carol_ A Ghost Story of Christmas",
+			"/audiobooks/Lewis Carroll/Alice's Adventures in Wonderland Version 2",
+		},
+		expectedCount: 2,
+	}
+}
+
+func absMetadataBookCase() absMetadataOrganizeCase {
+	return absMetadataOrganizeCase{
+		name:    "plain_books_move_using_abs_metadata",
+		library: booksLibrary,
+		inputParts: []string{
+			"test", "abs", "runtime", "plain", "books",
+		},
+		oldFiles: [][]string{
+			{"test", "abs", "runtime", "plain", "books", "imported", "ebook-001.epub"},
+			{"test", "abs", "runtime", "plain", "books", "random", "shelley-book.epub"},
+			{"test", "abs", "runtime", "plain", "books", "to-sort", "austen.epub"},
+		},
+		newFiles: [][]string{
+			{
+				"test",
+				"abs",
+				"runtime",
+				"plain",
+				"books",
+				"Lewis Carroll",
+				"Alice's Adventures in Wonderland",
+				"ebook-001.epub",
+			},
+			{
+				"test",
+				"abs",
+				"runtime",
+				"plain",
+				"books",
+				"Mary Wollstonecraft Shelley",
+				"Frankenstein; or, the modern prometheus",
+				"shelley-book.epub",
+			},
+			{
+				"test",
+				"abs",
+				"runtime",
+				"plain",
+				"books",
+				"Jane Austen",
+				"Pride and Prejudice",
+				"austen.epub",
+			},
+		},
+		logFile: []string{
+			"test", "abs", "runtime", "plain", "books", ".abook-org.log",
+		},
+		oldAPIPaths: []string{
+			"/books/imported",
+			"/books/random",
+			"/books/to-sort",
+		},
+		newAPIPaths: []string{
+			"/books/Jane Austen/Pride and Prejudice",
+			"/books/Lewis Carroll/Alice's Adventures in Wonderland",
+			"/books/Mary Wollstonecraft Shelley/Frankenstein; or, the modern prometheus",
+		},
+		expectedCount: 3,
+		seedAuthors: map[string]string{
+			"/books/imported": "Lewis Carroll",
+			"/books/random":   "Mary Wollstonecraft Shelley",
+			"/books/to-sort":  "Jane Austen",
+		},
+	}
+}
+
+func runABSMetadataOrganizeLifecycle(t *testing.T, tc absMetadataOrganizeCase) {
+	var ctx absScenarioContext
+
+	step(t, "01 reset and initial ABS scan", func(t *testing.T) {
+		resetAndInitialScan(t)
+		ctx = newABSScenarioContext(t, plainInstance, tc.library)
+	})
+
+	step(t, "02 seed ABS metadata required by fixture", func(t *testing.T) {
+		seedABSAuthors(t, ctx, tc.seedAuthors)
+	})
+
+	step(t, "03 assert ABS starts with messy active paths", func(t *testing.T) {
+		waitForABSState(t, ctx, absStateExpectation{
+			expectedCount:  tc.expectedCount,
+			missingCount:   0,
+			activeContains: tc.oldAPIPaths,
+			absentContains: tc.newAPIPaths,
+		})
+	})
+
+	step(t, "04 run abs organize", func(t *testing.T) {
+		output := runOrganizer(
+			t,
+			"abs", "organize",
+			"--abs-url", os.Getenv(plainInstance.envURL),
+			"--abs-token", os.Getenv("ABS_TOKEN"),
+			"--abs-library", tc.library.name,
+			"--abs-path-map", pathMap(tc.library, plainInstance),
+			"--dir", pathFromRoot(tc.inputParts...),
+			"--layout", "author-title",
+		)
+		assertOutputContains(t, output, "Organizing with ABS metadata", "Moves planned/executed")
+	})
+
+	step(t, "05 assert filesystem result", func(t *testing.T) {
+		assertPathsNotExist(t, tc.oldFiles)
+		assertPathsExist(t, tc.newFiles)
+		assertExists(t, pathFromRoot(tc.logFile...))
+	})
+
+	step(t, "06 scan ABS after organizer run", func(t *testing.T) {
+		scanLibraryAndWait(t, ctx)
+	})
+
+	step(t, "07 assert ABS marks old paths missing and adds organized paths", func(t *testing.T) {
+		waitForABSState(t, ctx, absStateExpectation{
+			expectedCount:   tc.expectedCount * 2,
+			missingCount:    len(tc.oldAPIPaths),
+			activeContains:  tc.newAPIPaths,
+			missingContains: tc.oldAPIPaths,
+		})
+	})
+
+	step(t, "08 clean ABS library issues", func(t *testing.T) {
+		cleanMissingABSItems(t, ctx, tc.oldAPIPaths)
+	})
+
+	step(t, "09 scan ABS after cleanup", func(t *testing.T) {
+		scanLibraryAndWait(t, ctx)
+	})
+
+	step(t, "10 assert ABS final state is clean and organized", func(t *testing.T) {
+		waitForABSState(t, ctx, absStateExpectation{
+			expectedCount:  tc.expectedCount,
+			missingCount:   0,
+			activeContains: tc.newAPIPaths,
+			absentContains: tc.oldAPIPaths,
+		})
+	})
+}
+
+func seedABSAuthors(t *testing.T, ctx absScenarioContext, authorsByPath map[string]string) {
+	t.Helper()
+	if len(authorsByPath) == 0 {
+		return
+	}
+
+	state := waitForABSState(t, ctx, absStateExpectation{
+		expectedCount:  len(authorsByPath),
+		activeContains: keys(authorsByPath),
+	})
+	for path, author := range authorsByPath {
+		itemID := ""
+		for _, item := range state.items {
+			if item.Path == path {
+				itemID = item.ID
+				break
+			}
+		}
+		if itemID == "" {
+			t.Fatalf("could not find ABS item for metadata seed path %s", path)
+		}
+
+		err := ctx.client.UpdateLibraryItemMedia(itemID, map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"authors": []map[string]string{{"name": author}},
+			},
+		})
+		if err != nil {
+			t.Fatalf("seed ABS author metadata for %s: %v", path, err)
+		}
+	}
+}
+
+func pathMap(library absLibrary, instance absInstance) string {
+	return fmt.Sprintf("%s:%s", library.folderPath, localLibraryPath(instance, library))
+}
+
+func assertOutputContains(t *testing.T, output string, needles ...string) {
+	t.Helper()
+	for _, needle := range needles {
+		if !strings.Contains(output, needle) {
+			t.Fatalf("expected output to contain %q\noutput:\n%s", needle, output)
+		}
+	}
+}
+
+func keys(values map[string]string) []string {
+	result := make([]string, 0, len(values))
+	for key := range values {
+		result = append(result, key)
+	}
+	return result
+}

--- a/test/abs/e2e/matrix_todo_test.go
+++ b/test/abs/e2e/matrix_todo_test.go
@@ -1,9 +1,0 @@
-//go:build abs_e2e
-
-package e2e
-
-import "testing"
-
-func TestABSMatrixTODO_ABSMetadataModeLifecycle(t *testing.T) {
-	t.Fatal("TODO: build ABS metadata mode lifecycle tests")
-}

--- a/test/abs/test-matrix.md
+++ b/test/abs/test-matrix.md
@@ -138,12 +138,12 @@ specifically about series layout. It gives stable, easy-to-assert paths:
 | R3 | REST harness, flat import | plain | Audiobooks, Ebooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestRESTHarness_FlatModeImportLifecycle -count=1 -v` | Implemented. Imports loose MP3 and EPUB fixtures from outside ABS into mounted ABS libraries through `/api/organize/run`, scans through REST, and verifies imported flat-mode paths are active with zero missing rows. |
 | R4 | REST harness, web ABS setup endpoints | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestRESTHarness_ABSSetupEndpoints -count=1 -v` | Implemented. Runs the real Docker-backed ABS reset, loads libraries through `/api/abs/libraries`, and validates the manual `/audiobooks` to host path mapping through `/api/abs/test-paths`. This covers the real API boundary used by the web ABS setup controls; browser UI contract coverage in `web/tests/e2e/gui-smoke.spec.ts` verifies URL/token testing unlocks the discovered-library selector before path validation. |
 | R5 | REST harness, web ABS operation endpoints | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestRESTHarness_ABSOperationEndpoints -count=1 -v` | Implemented. Runs the real Docker-backed ABS reset, loads mapped ABS metadata through `/api/abs/items`, reads active/missing state through `/api/abs/library-state`, triggers scans through `/api/abs/scan-trigger`, moves a fixture folder out of the mounted library, and removes the resulting missing row through `/api/abs/clean-missing`. This covers the real API boundary used by the web ABS operation controls; browser UI contract coverage remains in `web/tests/e2e/gui-smoke.spec.ts`. |
-| A1 | ABS discovery | plain | both | `go run . abs scan --abs-url http://localhost:13378 --abs-token <token>` | Works today. Lists both libraries and item counts. Does not move files. |
-| A2 | ABS manual path mapping | plain | Audiobooks | `go run . abs scan --abs-url http://localhost:13378 --abs-token <token> --abs-library Audiobooks --abs-path-map "/audiobooks:<abs>/test/abs/runtime/plain/audiobooks" --dir <abs>/test/abs/runtime/plain/audiobooks --check-files` | Works today as preview/connectivity coverage. It fetches ABS metadata, maps ABS paths to host paths, checks files, and calculates target paths. It does not perform organization. |
-| A3 | ABS all-libraries preview | plain | both | `go run . abs scan --abs-url http://localhost:13378 --abs-token <token> --abs-all-libraries --abs-path-map "/audiobooks:<abs>/test/abs/runtime/plain/audiobooks" --abs-path-map "/books:<abs>/test/abs/runtime/plain/books" --dir <abs>/test/abs/runtime/plain --check-files` | Works today if all-libraries mode handles both mappings. Confirms ABS metadata can be loaded across both libraries. Does not move files. |
-| A4 | ABS scan trigger | plain | Audiobooks | `go run . abs scan-trigger --abs-url http://localhost:13378 --abs-token <token> --abs-library <id>` | Works today. Confirms organizer CLI can trigger ABS scan; detailed scan completion can still use `scan-libraries.sh` polling. |
-| A5 | ABS organize, already indexed | plain | Audiobooks | Future: `go run . abs organize --abs-url http://localhost:13378 --abs-token <token> --abs-library Audiobooks --abs-path-map "/audiobooks:<abs>/test/abs/runtime/plain/audiobooks" --dir <abs>/test/abs/runtime/plain/audiobooks --layout author-title` | Future behavior. Uses ABS metadata as the source of truth to move already-indexed files even when no `metadata.json` sidecars exist and embedded metadata is absent, sparse, or wrong. |
-| A6 | ABS organize, already indexed | plain | Ebooks | Future: same as A5 for `Ebooks` and `/books` | Future behavior. Confirms ABS metadata can drive organization of an already-indexed ebook library. |
+| A1 | ABS discovery | plain | both | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_PreviewAndScanTrigger -count=1 -v` | Implemented. Lists both libraries and exercises discovery without moving files. |
+| A2 | ABS manual path mapping | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_PreviewAndScanTrigger -count=1 -v` | Implemented. Fetches ABS metadata, maps ABS paths to host paths, checks files, and verifies audiobook authors/titles appear in preview output. |
+| A3 | ABS all-libraries preview | plain | both | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_PreviewAndScanTrigger -count=1 -v` | Implemented. Confirms all-libraries mode loads both `/audiobooks` and `/books` with explicit path mappings. |
+| A4 | ABS scan trigger | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_PreviewAndScanTrigger -count=1 -v` | Implemented. Triggers a scan through the CLI and verifies the ABS API state remains clean. |
+| A5 | ABS organize, already indexed | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_OrganizeAudiobooksLifecycle -count=1 -v` | Implemented. Uses ABS metadata as the source of truth to move already-indexed audiobook folders when no `metadata.json` sidecars are present; verifies filesystem moves, organizer log, ABS missing/new rows after scan, missing cleanup, and final clean ABS state. |
+| A6 | ABS organize, already indexed | plain | Ebooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_OrganizeBooksLifecycle -count=1 -v` | Implemented. Seeds explicit ABS author metadata through the ABS media-update API, then organizes already-indexed EPUB folders using ABS metadata and verifies the same filesystem, scan, cleanup, and final-state lifecycle as A5. |
 
 ## Per-Test Verification
 
@@ -191,6 +191,7 @@ cycle, so the fixed ABS ports do not conflict:
 | `rest-flat-import` | `TestRESTHarness_FlatModeImportLifecycle` |
 | `rest-abs-setup` | `TestRESTHarness_ABSSetupEndpoints` |
 | `rest-abs-operations` | `TestRESTHarness_ABSOperationEndpoints` |
+| `abs-metadata-mode` | `TestABSMetadataMode` |
 
 Local `make abs-test-matrix` still runs all implemented rows serially. To run
 one row locally, pass the same regex:
@@ -288,13 +289,13 @@ Flat import tests use `--out` to place organized files into `/audiobooks` or
 were outside ABS before the organizer run, these tests should not create missing
 ABS rows.
 
-## ABS Mode Gaps
+## ABS Metadata Organization
 
-The current `audiobook-organizer abs scan` command is preview/connectivity-only.
-It fetches ABS metadata, maps paths, and prints proposed target paths, but it
-does not yet move files through the organizer core.
+`audiobook-organizer abs scan` is the preview/connectivity command. It fetches
+ABS metadata, maps paths, and prints proposed target paths.
 
-The desired ABS mode is a new execution path for files already indexed by ABS:
+`audiobook-organizer abs organize` is the execution path for files already
+indexed by ABS:
 
 ```text
 ABS API item metadata + ABS path mapping -> organizer target path -> filesystem move -> ABS scan
@@ -304,26 +305,10 @@ This mode is especially useful for the plain ABS instance, where no
 `metadata.json` sidecars are stored with items. It should also work when embedded
 metadata is missing, incomplete, or lower quality than ABS metadata.
 
-Until ABS organization is implemented, ABS-mode tests should cover:
-
-- authentication and discovery,
-- manual path mapping,
-- library item fetch and file existence checks,
-- scan trigger.
-
 SQLite path discovery is a separate implementation gap. The current committed
 ABS baseline schema has `libraryFolders(path)`, while `internal/abs/path_mapper.go`
 expects a newer or different `folders` table with `fullPath`. Until that code is
 updated, use explicit `--abs-path-map` in harness tests.
-
-Once ABS mode can perform organization, add tests mirroring M1/M2:
-
-- ABS metadata as source of truth,
-- move files in the mounted runtime library,
-- trigger ABS scan,
-- assert ABS item paths changed to the organizer target paths.
-It should be tested against the plain instance first because that instance does
-not write `metadata.json` sidecars, forcing the command to use ABS metadata.
 
 ## Initial Implementation Order
 
@@ -336,6 +321,6 @@ not write `metadata.json` sidecars, forcing the command to use ABS metadata.
 5. Add import fixtures and embedded hierarchical import tests M2C-M2D.
 6. Add flat mechanics tests M3A-M3B with temporary non-ABS output. Implemented.
 7. Add flat import fixtures and tests M3C-M3D. Implemented.
-8. Add ABS preview tests A1-A4.
-9. Stub or implement ABS organize mode A5-A6.
+8. Add ABS preview tests A1-A4. Implemented.
+9. Implement ABS organize mode A5-A6. Implemented.
 10. Fix or replace SQLite path discovery for this ABS schema.


### PR DESCRIPTION
Resolves #29

## Summary

- Adds `audiobook-organizer abs organize` for already-indexed ABS items, reusing the normal organizer move, dry-run, undo, layout, logging, skip-errors, prompt, and remove-empty behavior.
- Converts ABS API metadata into organizer metadata, including ABS top-level author-name fallbacks and raw fields for existing field-mapping flags.
- Adds real Docker-backed ABS matrix coverage for discovery, manual path mapping, all-libraries preview, scan trigger, audiobook organization, ebook organization, ABS cleanup, and final clean ABS state.
- Updates ABS docs, changelog, matrix docs, Makefile default ABS regex, and GitHub Actions ABS matrix row.

## Tests

- `go test ./cmd ./internal/organizer ./internal/abs`
- `make test-unit`
- `make abs-test-matrix ABS_TEST_RUN=TestABSMetadataMode`
- `prek run --all-files`

## Docs / Matrix

- Updated `README.md`, `docs/CLI.md`, and `CHANGELOG.md`.
- Updated `test/abs/test-matrix.md`.
- Added `abs-metadata-mode` to the ABS GitHub Actions matrix.

## Notes

- SQLite path discovery remains a separate existing matrix gap; this command and the new tests use explicit `--abs-path-map`.
