### PR TITLE
Run web UI Playwright tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,57 @@ jobs:
       run: |
         go tool cover -func=coverage.out
 
+  web-ui-e2e:
+    name: Web UI Playwright
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: 'stable'
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Set up Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+        cache: npm
+        cache-dependency-path: web/package-lock.json
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('web/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
+    - name: Install frontend dependencies
+      working-directory: web
+      run: npm ci
+
+    - name: Install Playwright Chromium
+      working-directory: web
+      run: npx playwright install --with-deps chromium
+
+    - name: Run Playwright web UI tests
+      run: make gui-test
+
+    - name: Upload Playwright artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: web-ui-playwright-artifacts
+        path: |
+          web/playwright-report/**
+          web/test-results/**
+
   abs-e2e:
     name: ABS matrix / ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the README overview, repository metadata, and web page metadata so search results describe the project as an audiobook organizer and renamer for Audiobookshelf with `metadata.json`, EPUB, MP3, and M4B support.
 - Rewrote the root README for the single-binary web UI direction and current command surface.
 - Split the Audiobookshelf E2E matrix into parallel GitHub Actions jobs for faster feedback.
+- Added the local web UI Playwright suite to GitHub Actions so browser regressions run in CI with failure artifacts.
 - Added a first-class Audiobookshelf smoke/reset matrix row for the reset, baseline restore, startup, scan, metadata setting, and initial item count contract.
 - Clarified agent Gitflow rules for issue branches, worktree hook installation, PR merge strategy, branch verification, and closeout through merge back to `master`.
 - Documented protected `master` workflow rules for required checks, auto-merge, and branch cleanup.

--- a/docs/GUI_TESTING.md
+++ b/docs/GUI_TESTING.md
@@ -31,6 +31,12 @@ make gui-test-headed
 make gui-test-ui
 ```
 
+CI runs the same browser suite in the `Web UI Playwright` job. The job installs
+frontend dependencies with `npm ci`, installs Playwright-managed Chromium with
+Linux browser dependencies, and then runs `make gui-test`. On failure it uploads
+the Playwright HTML report, traces, screenshots, and videos from
+`web/playwright-report/` and `web/test-results/`.
+
 Direct npm equivalents:
 
 ```bash
@@ -56,15 +62,25 @@ If Playwright reports a missing executable such as `chromium_headless_shell-<rev
 
 ## Current Coverage
 
-The initial suite covers:
+The current suite covers:
 
-- REST tests for auth, config/options, static app serving, method validation, malformed JSON, organize preview, rename preview, and no-Docker ABS path mapping validation.
-- The local Go web server starts and serves embedded assets.
-- Authenticated API endpoints reject missing tokens and accept the generated session token.
+- REST tests for auth, config/options, static app serving, method validation,
+  malformed JSON, organize preview, rename preview, and no-Docker ABS path
+  mapping validation.
+- The local Go web server starts with a generated session token and serves the
+  embedded web app.
+- Authenticated API endpoints reject missing tokens and accept the generated
+  session token.
 - The dashboard renders without browser console warnings or errors.
-- The health check changes the server status to connected.
-- Table selection updates the inspector.
-- The scan button writes a visible job-console event.
+- Workflow navigation, backend bootstrap state, folder picker/drop behavior,
+  narrow viewport overflow checks, and bootstrap fallback states.
+- Real organize preview and execution against temporary filesystem fixtures.
+- Real rename preview against temporary filesystem fixtures, including
+  conflicts, skipped files, extraction errors, and the current deferred
+  execution state.
+- Mocked browser contract checks for ABS setup and operations. Real ABS behavior
+  is covered by the Docker-backed Go E2E matrix until browser-driven ABS tests
+  are added.
 
 ## Expansion Plan
 


### PR DESCRIPTION
Resolves #102

## Summary

- Add a `Web UI Playwright` GitHub Actions job that installs Go, Node, frontend dependencies, and Playwright-managed Chromium with Linux browser dependencies.
- Cache npm and Playwright browser payloads while still running `npx playwright install --with-deps chromium` so the job does not depend on stale cached browser revisions.
- Upload Playwright report, trace, screenshot, and video artifacts on failure.
- Update GUI testing docs to describe CI behavior and current browser coverage.

## Tests

- `make gui-test` passed locally with elevated loopback bind permission; the default sandbox blocks `127.0.0.1:0` with `bind: operation not permitted`.
- `go test ./internal/app ./internal/server`
- `git diff --check`
- `prek run --all-files`

## Docs / Changelog

- Updated `docs/GUI_TESTING.md`.
- Updated `CHANGELOG.md`.

## Notes

- `make fmt-check` is still blocked by ignored local debug Go files outside this branch: `debug_booklist.go`, `debug_script.go`, `debug_tui.go`, `test_debug.go`, and `tui_test.go`.
