### PR TITLE
Add real ABS Playwright coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,96 @@ jobs:
           web/playwright-report/**
           web/test-results/**
 
+  web-ui-abs-e2e:
+    name: Web UI ABS Playwright
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      ABS_IMAGE: ghcr.io/advplyr/audiobookshelf:latest
+      ABS_FIXTURE_CACHE_DIR: test/abs/.cache/staging-data
+      ABS_IMAGE_TAR: test/abs/.cache/docker/audiobookshelf-latest.tar
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: 'stable'
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Set up Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+        cache: npm
+        cache-dependency-path: web/package-lock.json
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('web/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
+    - name: Cache ABS public-domain fixtures
+      uses: actions/cache@v5
+      with:
+        path: test/abs/.cache/staging-data
+        key: ${{ runner.os }}-abs-fixtures-v2-${{ hashFiles('test/abs/scripts/seed-public-domain.sh') }}
+        restore-keys: |
+          ${{ runner.os }}-abs-fixtures-v2-
+
+    - name: Cache ABS Docker image
+      uses: actions/cache@v5
+      with:
+        path: test/abs/.cache/docker/audiobookshelf-latest.tar
+        key: ${{ runner.os }}-abs-docker-image-latest-v1
+
+    - name: Show Docker version
+      run: |
+        docker version
+        docker compose version
+
+    - name: Load or pull ABS Docker image
+      run: |
+        mkdir -p test/abs/.cache/docker
+        if [ -s "$ABS_IMAGE_TAR" ]; then
+          docker load -i "$ABS_IMAGE_TAR"
+        else
+          docker pull "$ABS_IMAGE"
+          docker save -o "$ABS_IMAGE_TAR" "$ABS_IMAGE"
+        fi
+
+    - name: Install frontend dependencies
+      working-directory: web
+      run: npm ci
+
+    - name: Install Playwright Chromium
+      working-directory: web
+      run: npx playwright install --with-deps chromium
+
+    - name: Run ABS-backed Playwright web UI test
+      run: make gui-test-abs
+
+    - name: Stop ABS containers
+      if: always()
+      run: docker compose -f test/abs/docker-compose.yml down --remove-orphans
+
+    - name: Upload ABS Playwright artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: web-ui-abs-playwright-artifacts
+        path: |
+          web/playwright-report/**
+          web/test-results/**
+          test/abs/state/**/metadata/logs/**
+          test/abs/runtime/**/*.log
+
   abs-e2e:
     name: ABS matrix / ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **REST execution coverage for ABS workflows**: Added Docker-backed REST tests for `metadata.json`, embedded metadata import, and flat import workflows against real Audiobookshelf containers.
 - **Flat mode ABS coverage**: Added Docker-backed flat mechanics and flat ebook import matrix coverage for Audiobookshelf workflows.
 - **Embedded EPUB ABS coverage**: Added Docker-backed already-indexed EPUB current-behavior coverage for embedded metadata workflows.
+- **ABS browser UI coverage**: Added Docker-backed Playwright coverage for the web Audiobookshelf setup and operation controls against real ABS instances.
 - **ABS metadata organization**: Added `audiobook-organizer abs organize` so already-indexed Audiobookshelf items can be reorganized with ABS API metadata while reusing the normal organizer move, dry-run, undo, layout, logging, and scan follow-up flow.
 - **Text-only metadata inspection**: `audiobook-organizer metadata` now prints non-interactive metadata scan results, `metadata --json` writes machine-readable output, and `metadata-tui` keeps the old interactive metadata exploration workflow explicit.
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ INTEGRATION_TEST_PKGS = $(shell go list ./... | grep -v '/integration$$')
 ABS_TEST_RUN ?= Test(ABSHarnessSmokeResetContract|MetadataJSONMode|EmbeddedAlreadyIndexed|EmbeddedMetadataImport|FlatMode(Mechanics|Import)|RESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints)|ABSMetadataMode)
 ABS_REST_TEST_RUN ?= TestRESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints)
 
-.PHONY: all build clean dev dev-linux-amd64 web-install web-build web-dev gui-rest-test gui-test gui-test-headed gui-test-ui abs-dev-seed abs-dev-init abs-dev-configure abs-dev-up abs-dev-down abs-dev-reset abs-dev-reset-all abs-dev-scan abs-dev-reset-scan abs-ci-smoke abs-test-metadata abs-test-rest abs-test-matrix abs-test-e2e abs-dev-capture-baseline abs-dev-restore-baseline abs-dev-wait release test test-unit test-integration coverage coverage-html lint fmt fmt-check vet help scp-dev
+.PHONY: all build clean dev dev-linux-amd64 web-install web-build web-dev gui-rest-test gui-test gui-test-abs gui-test-headed gui-test-ui abs-dev-seed abs-dev-init abs-dev-configure abs-dev-up abs-dev-down abs-dev-reset abs-dev-reset-all abs-dev-scan abs-dev-reset-scan abs-ci-smoke abs-test-metadata abs-test-rest abs-test-matrix abs-test-e2e abs-dev-capture-baseline abs-dev-restore-baseline abs-dev-wait release test test-unit test-integration coverage coverage-html lint fmt fmt-check vet help scp-dev
 
 # Default target - show help
 all: help
@@ -34,6 +34,7 @@ help:
 	@printf "    %-26s %s\n" "web-dev" "Run the web frontend dev server"
 	@printf "    %-26s %s\n" "gui-rest-test" "Run local web UI REST endpoint tests"
 	@printf "    %-26s %s\n" "gui-test" "Run local web UI Playwright tests"
+	@printf "    %-26s %s\n" "gui-test-abs" "Run Docker-backed ABS web UI Playwright test"
 	@printf "    %-26s %s\n" "gui-test-headed" "Run local web UI Playwright tests headed"
 	@printf "    %-26s %s\n" "gui-test-ui" "Open Playwright UI runner for local web UI tests"
 	@printf "    %-26s %s\n" "scp-dev" "Copy linux-amd64 binary to remote server"
@@ -106,6 +107,11 @@ gui-rest-test:
 # Run local web UI Playwright tests
 gui-test:
 	cd web && npm run test:e2e
+
+# Run Docker-backed local web UI Playwright ABS test
+gui-test-abs:
+	@test/abs/scripts/seed-public-domain.sh
+	cd web && ABO_ABS_PLAYWRIGHT=1 npm run test:e2e -- --project=chromium-desktop tests/e2e/abs-real.spec.ts
 
 # Run local web UI Playwright tests in headed mode
 gui-test-headed:

--- a/docs/GUI_TESTING.md
+++ b/docs/GUI_TESTING.md
@@ -24,6 +24,9 @@ make gui-rest-test
 # Build Vue assets and run Playwright headless tests
 make gui-test
 
+# Run the Docker-backed browser test for real ABS setup and operations
+make gui-test-abs
+
 # Run headed for local debugging
 make gui-test-headed
 
@@ -31,11 +34,17 @@ make gui-test-headed
 make gui-test-ui
 ```
 
-CI runs the same browser suite in the `Web UI Playwright` job. The job installs
-frontend dependencies with `npm ci`, installs Playwright-managed Chromium with
-Linux browser dependencies, and then runs `make gui-test`. On failure it uploads
-the Playwright HTML report, traces, screenshots, and videos from
-`web/playwright-report/` and `web/test-results/`.
+CI runs the normal browser suite in the `Web UI Playwright` job. The job
+installs frontend dependencies with `npm ci`, installs Playwright-managed
+Chromium with Linux browser dependencies, and then runs `make gui-test`. On
+failure it uploads the Playwright HTML report, traces, screenshots, and videos
+from `web/playwright-report/` and `web/test-results/`.
+
+CI runs the Docker-backed ABS browser suite separately in the `Web UI ABS
+Playwright` job with `make gui-test-abs`. That job seeds the ABS fixtures,
+resets both ABS containers through the normal harness reset contract, starts the
+real Go web UI, and drives the browser through the real ABS setup and operation
+endpoints.
 
 Direct npm equivalents:
 
@@ -44,6 +53,7 @@ cd web
 npm install
 npm run install:browsers
 npm run test:e2e
+ABO_ABS_PLAYWRIGHT=1 npm run test:e2e -- --project=chromium-desktop tests/e2e/abs-real.spec.ts
 npm run test:e2e:headed
 npm run test:e2e:ui
 ```
@@ -78,9 +88,11 @@ The current suite covers:
 - Real rename preview against temporary filesystem fixtures, including
   conflicts, skipped files, extraction errors, and the current deferred
   execution state.
-- Mocked browser contract checks for ABS setup and operations. Real ABS behavior
-  is covered by the Docker-backed Go E2E matrix until browser-driven ABS tests
-  are added.
+- Mocked browser contract checks for ABS setup and operations.
+- Real browser-driven ABS setup and operation coverage against the Docker ABS
+  harness, including URL/token entry, library discovery, path mapping
+  validation, metadata-item loading, library-state loading, scan triggering,
+  destructive cleanup gating, and missing-item cleanup.
 
 ## Expansion Plan
 
@@ -89,7 +101,6 @@ As the GUI moves from scaffold to real workflows, add tests in this order:
 1. Real source/output configuration state.
 2. Organize preview API calls with fixture directories.
 3. Rename preview API calls with fixture files.
-4. ABS library discovery and path mapping using the local ABS harness.
-5. Scan-trigger and missing-item cleanup flows after organizer moves.
-6. Accessibility checks for keyboard navigation and visible focus states.
-7. Visual regression snapshots for the main desktop and mobile layouts.
+4. Browser-driven ABS organize/import flows after ABS metadata setup.
+5. Accessibility checks for keyboard navigation and visible focus states.
+6. Visual regression snapshots for the main desktop and mobile layouts.

--- a/test/abs/test-matrix.md
+++ b/test/abs/test-matrix.md
@@ -138,6 +138,7 @@ specifically about series layout. It gives stable, easy-to-assert paths:
 | R3 | REST harness, flat import | plain | Audiobooks, Ebooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestRESTHarness_FlatModeImportLifecycle -count=1 -v` | Implemented. Imports loose MP3 and EPUB fixtures from outside ABS into mounted ABS libraries through `/api/organize/run`, scans through REST, and verifies imported flat-mode paths are active with zero missing rows. |
 | R4 | REST harness, web ABS setup endpoints | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestRESTHarness_ABSSetupEndpoints -count=1 -v` | Implemented. Runs the real Docker-backed ABS reset, loads libraries through `/api/abs/libraries`, and validates the manual `/audiobooks` to host path mapping through `/api/abs/test-paths`. This covers the real API boundary used by the web ABS setup controls; browser UI contract coverage in `web/tests/e2e/gui-smoke.spec.ts` verifies URL/token testing unlocks the discovered-library selector before path validation. |
 | R5 | REST harness, web ABS operation endpoints | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestRESTHarness_ABSOperationEndpoints -count=1 -v` | Implemented. Runs the real Docker-backed ABS reset, loads mapped ABS metadata through `/api/abs/items`, reads active/missing state through `/api/abs/library-state`, triggers scans through `/api/abs/scan-trigger`, moves a fixture folder out of the mounted library, and removes the resulting missing row through `/api/abs/clean-missing`. This covers the real API boundary used by the web ABS operation controls; browser UI contract coverage remains in `web/tests/e2e/gui-smoke.spec.ts`. |
+| W1 | Browser UI, ABS setup and operations | plain | Audiobooks | `make gui-test-abs` | Implemented. Runs the real Docker-backed ABS reset, starts the real Go web UI, drives Playwright through ABS URL/token entry, library discovery, path mapping validation, ABS item loading, library-state loading, scan triggering, missing-row detection after moving a mounted folder, destructive cleanup gating, cleanup, rescan, and final clean rendered state. |
 | A1 | ABS discovery | plain | both | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_PreviewAndScanTrigger -count=1 -v` | Implemented. Lists both libraries and exercises discovery without moving files. |
 | A2 | ABS manual path mapping | plain | Audiobooks | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_PreviewAndScanTrigger -count=1 -v` | Implemented. Fetches ABS metadata, maps ABS paths to host paths, checks files, and verifies audiobook authors/titles appear in preview output. |
 | A3 | ABS all-libraries preview | plain | both | `go test -tags=abs_e2e ./test/abs/e2e -run TestABSMetadataMode_PreviewAndScanTrigger -count=1 -v` | Implemented. Confirms all-libraries mode loads both `/audiobooks` and `/books` with explicit path mappings. |
@@ -192,6 +193,10 @@ cycle, so the fixed ABS ports do not conflict:
 | `rest-abs-setup` | `TestRESTHarness_ABSSetupEndpoints` |
 | `rest-abs-operations` | `TestRESTHarness_ABSOperationEndpoints` |
 | `abs-metadata-mode` | `TestABSMetadataMode` |
+
+The browser-backed ABS row `W1` runs in its own GitHub Actions job with
+`make gui-test-abs` because it requires both Playwright-managed Chromium and the
+Docker ABS harness.
 
 Local `make abs-test-matrix` still runs all implemented rows serially. To run
 one row locally, pass the same regex:

--- a/web/tests/e2e/abs-real.spec.ts
+++ b/web/tests/e2e/abs-real.spec.ts
@@ -1,0 +1,231 @@
+import { spawn } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { mkdtemp, rename } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test, type Page } from '@playwright/test'
+import { startTestServer, type TestServer } from './server'
+
+const repoRoot = new URL('../../..', import.meta.url).pathname
+
+let server: TestServer
+let absEnv: Record<string, string>
+
+test.skip(process.env.ABO_ABS_PLAYWRIGHT !== '1', 'Set ABO_ABS_PLAYWRIGHT=1 to run Docker-backed ABS UI tests.')
+
+test.beforeAll(async () => {
+  await runRepoCommand('make', ['abs-dev-reset-scan'], 8 * 60_000)
+  absEnv = loadABSTestingEnv()
+  server = await startTestServer()
+})
+
+test.afterAll(async () => {
+  await server?.stop()
+})
+
+test('drives ABS setup and operations against the real ABS harness', async ({ page }) => {
+  test.setTimeout(120_000)
+
+  const absURL = requiredEnv('ABS_PLAIN_URL')
+  const absToken = requiredEnv('ABS_TOKEN')
+  const audiobookRoot = join(repoRoot, 'test', 'abs', 'runtime', 'plain', 'audiobooks')
+
+  await loadApp(page)
+  await page.getByRole('button', { name: /Audiobookshelf/ }).click()
+  await page.getByRole('textbox', { name: 'Source folder' }).fill(audiobookRoot)
+  await page.getByLabel('ABS server URL').fill(absURL)
+  await page.getByLabel('ABS API token').fill(absToken)
+  await page.getByLabel('ABS path prefix').fill('/audiobooks')
+  await page.getByLabel('Local path prefix').fill(audiobookRoot)
+
+  await page.getByRole('button', { name: 'Test Connection' }).click()
+  const librarySelect = page.getByLabel('ABS library')
+  await expect(librarySelect).toBeVisible()
+  await selectLibraryByName(page, 'Audiobooks')
+  await expect(page.locator('.library-option.selected').filter({ hasText: 'Audiobooks' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Validate Paths' }).click()
+  await expect(page.getByText('ABS libraries loaded and path mappings validated.')).toBeVisible()
+  await expect(page.getByText(audiobookRoot).first()).toBeVisible()
+
+  await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+  await expect(page.getByRole('button', { name: 'Load ABS Items' })).toBeEnabled()
+  await expect(page.getByRole('button', { name: 'Check Library State' })).toBeEnabled()
+  await page.getByRole('button', { name: 'Load ABS Items' }).click()
+  await page.getByRole('button', { name: 'Check Library State' }).click()
+
+  await expect(page.getByRole('heading', { name: 'ABS operation data ready' })).toBeVisible()
+  await expectSummaryValue(page, 'Metadata items', '2')
+  await expectSummaryValue(page, 'Library items', '2')
+  await expectSummaryValue(page, 'Missing / invalid', '0 / 0')
+  await expect(page.getByText(audiobookRoot).first()).toBeVisible()
+
+  const missingSource = join(audiobookRoot, 'loose')
+  const missingTarget = join(await mkdtemp(join(tmpdir(), 'abo-web-abs-missing-')), 'loose')
+  await rename(missingSource, missingTarget)
+
+  await page.getByRole('button', { name: 'Run Execute after review' }).click()
+  await page.getByRole('button', { name: 'Trigger Scan' }).click()
+  await expect(page.getByText(/Scan triggered for/)).toBeVisible()
+
+  await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+  await waitForMissingState(page)
+  await expect(page.locator('.move-list em').filter({ hasText: 'Missing' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Run Execute after review' }).click()
+  await expect(page.getByRole('button', { name: 'Clean Missing Items' })).toBeDisabled()
+
+  await page.getByLabel('I understand this removes ABS missing item records').check()
+  page.once('dialog', async (dialog) => {
+    expect(dialog.message()).toContain('Clean missing ABS item records')
+    await dialog.accept()
+  })
+  await page.getByRole('button', { name: 'Clean Missing Items' }).click()
+  await expect(page.getByText(/Cleanup completed for/)).toBeVisible()
+
+  await page.getByRole('button', { name: 'Trigger Scan' }).click()
+  await expect(page.getByText(/Scan triggered for/)).toBeVisible()
+  await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+  await waitForCleanState(page)
+  await expectSummaryValue(page, 'Library items', '1')
+  await expectSummaryValue(page, 'Missing / invalid', '0 / 0')
+
+  await page.getByRole('button', { name: 'Review Inspect backend results' }).click()
+  await expect(page.getByRole('heading', { name: 'ABS Operation Results' })).toBeVisible()
+  await expect(page.locator('.review-layout .result-grid')).toContainText('Library state items')
+  await expect(page.locator('.review-layout .result-grid')).toContainText('Last cleanup')
+})
+
+async function waitForMissingState(page: Page): Promise<void> {
+  await waitForLibraryState(page, async () => {
+    const missingBadgeCount = await page.locator('.move-list em').filter({ hasText: 'Missing' }).count()
+    return missingBadgeCount > 0
+  })
+}
+
+async function waitForCleanState(page: Page): Promise<void> {
+  await waitForLibraryState(page, async () => {
+    const missingBadgeCount = await page.locator('.move-list em').filter({ hasText: 'Missing' }).count()
+    const summary = await summaryValue(page, 'Missing / invalid')
+    return missingBadgeCount === 0 && summary === '0 / 0'
+  })
+}
+
+async function waitForLibraryState(page: Page, done: () => Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + 60_000
+  let lastSummary = ''
+
+  while (Date.now() < deadline) {
+    const checkState = page.getByRole('button', { name: 'Check Library State' })
+    await expect(checkState).toBeEnabled()
+    await checkState.click()
+    await expect(page.getByRole('heading', { name: /ABS operation/ })).toBeVisible()
+    lastSummary = await summaryValue(page, 'Missing / invalid')
+    if (await done()) {
+      return
+    }
+    await page.waitForTimeout(2_000)
+  }
+
+  throw new Error(`Timed out waiting for ABS library state. Last Missing / invalid summary: ${lastSummary}`)
+}
+
+async function selectLibraryByName(page: Page, libraryName: string): Promise<void> {
+  const option = page.getByLabel('ABS library').locator('option', { hasText: libraryName }).first()
+  const value = await option.getAttribute('value')
+  if (!value) {
+    throw new Error(`ABS library option not found: ${libraryName}`)
+  }
+  await page.getByLabel('ABS library').selectOption(value)
+}
+
+async function loadApp(page: Page): Promise<void> {
+  const consoleMessages: string[] = []
+  page.on('console', (message) => {
+    if (['error', 'warning'].includes(message.type())) {
+      consoleMessages.push(`${message.type()}: ${message.text()}`)
+    }
+  })
+
+  await page.goto(server.url)
+  await expect(page.locator('#app')).not.toBeEmpty()
+
+  expect(consoleMessages, 'No browser console warnings/errors during initial render').toEqual([])
+}
+
+async function expectSummaryValue(page: Page, label: string, value: string): Promise<void> {
+  await expect(summaryLocator(page, label)).toHaveText(value)
+}
+
+async function summaryValue(page: Page, label: string): Promise<string> {
+  return (await summaryLocator(page, label).textContent())?.trim() ?? ''
+}
+
+function summaryLocator(page: Page, label: string) {
+  return page.locator(`.result-grid.compact >> xpath=./span[normalize-space(.)="${label}"]/following-sibling::strong[1]`)
+}
+
+function loadABSTestingEnv(): Record<string, string> {
+  const envPath = join(repoRoot, 'test', 'abs', '.env.testing')
+  const data = readFileSync(envPath, 'utf8')
+  const values: Record<string, string> = {}
+  for (const line of data.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+    const separator = trimmed.indexOf('=')
+    if (separator === -1) {
+      continue
+    }
+    values[trimmed.slice(0, separator)] = trimmed.slice(separator + 1)
+  }
+  return values
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name] || absEnv[name]
+  if (!value) {
+    throw new Error(`${name} is required for ABS Playwright tests`)
+  }
+  return value
+}
+
+async function runRepoCommand(command: string, args: string[], timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        ABS_ENV_FILE: 'test/abs/.env.testing',
+        NO_COLOR: '1',
+        TERM: 'dumb',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let output = ''
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`${command} ${args.join(' ')} timed out after ${timeoutMs}ms\n${output}`))
+    }, timeoutMs)
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      output += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      output += chunk.toString()
+    })
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(new Error(`${command} ${args.join(' ')} failed: code=${code} signal=${signal}\n${output}`))
+    })
+  })
+}


### PR DESCRIPTION
Resolves #101.\n\nSummary:\n- Add an opt-in Playwright spec that starts the real Go web UI, resets the Docker ABS harness, and drives ABS setup and operation controls without route mocks.\n- Add make gui-test-abs and a dedicated Web UI ABS Playwright CI job with ABS fixture/image caching and failure artifacts.\n- Document the new command and record the browser-backed ABS matrix row plus changelog entry.\n\nTests:\n- make gui-test-abs\n- make gui-test\n- go test ./internal/app ./internal/server\n- git diff --check\n- prek run --all-files\n- make fmt-check (fails on unrelated ignored local debug Go files: debug_booklist.go, debug_script.go, debug_tui.go, test_debug.go, tui_test.go)