### PR TITLE
Expand real organize Playwright coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Flat mode ABS coverage**: Added Docker-backed flat mechanics and flat ebook import matrix coverage for Audiobookshelf workflows.
 - **Embedded EPUB ABS coverage**: Added Docker-backed already-indexed EPUB current-behavior coverage for embedded metadata workflows.
 - **ABS browser UI coverage**: Added Docker-backed Playwright coverage for the web Audiobookshelf setup and operation controls against real ABS instances.
+- **Organize browser coverage**: Expanded real Playwright coverage for embedded EPUB metadata, numbered layouts, remove-empty execution, dry-run behavior, undo-log creation, and real backend path validation errors.
 - **ABS metadata organization**: Added `audiobook-organizer abs organize` so already-indexed Audiobookshelf items can be reorganized with ABS API metadata while reusing the normal organizer move, dry-run, undo, layout, logging, and scan follow-up flow.
 - **Text-only metadata inspection**: `audiobook-organizer metadata` now prints non-interactive metadata scan results, `metadata --json` writes machine-readable output, and `metadata-tui` keeps the old interactive metadata exploration workflow explicit.
 

--- a/docs/GUI_TESTING.md
+++ b/docs/GUI_TESTING.md
@@ -84,7 +84,10 @@ The current suite covers:
 - The dashboard renders without browser console warnings or errors.
 - Workflow navigation, backend bootstrap state, folder picker/drop behavior,
   narrow viewport overflow checks, and bootstrap fallback states.
-- Real organize preview and execution against temporary filesystem fixtures.
+- Real organize preview and execution against temporary filesystem fixtures,
+  including `metadata.json`, embedded EPUB metadata, numbered layout selection,
+  remove-empty execution, dry-run immutability, undo-log creation, and backend
+  path validation errors.
 - Real rename preview against temporary filesystem fixtures, including
   conflicts, skipped files, extraction errors, and the current deferred
   execution state.
@@ -98,9 +101,7 @@ The current suite covers:
 
 As the GUI moves from scaffold to real workflows, add tests in this order:
 
-1. Real source/output configuration state.
-2. Organize preview API calls with fixture directories.
-3. Rename preview API calls with fixture files.
-4. Browser-driven ABS organize/import flows after ABS metadata setup.
-5. Accessibility checks for keyboard navigation and visible focus states.
-6. Visual regression snapshots for the main desktop and mobile layouts.
+1. Rename execution once the backend run endpoint exists.
+2. Browser-driven ABS organize/import flows after ABS metadata setup.
+3. Accessibility checks for keyboard navigation and visible focus states.
+4. Visual regression snapshots for the main desktop and mobile layouts.

--- a/web/tests/e2e/organize-real.spec.ts
+++ b/web/tests/e2e/organize-real.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test, type Page } from '@playwright/test'
-import { access, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { access, copyFile, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { startTestServer, type TestServer } from './server'
+
+const repoRoot = new URL('../../..', import.meta.url).pathname
 
 let server: TestServer
 
@@ -68,7 +70,118 @@ test('runs organize preview and execution against real filesystem fixtures', asy
     await expect(page.getByText('Not created')).toHaveCount(0)
     await expect(page.getByText('None yet')).toHaveCount(0)
     await expect.poll(() => pathExists(fixture.expectedFile)).toBe(true)
+    await expect.poll(() => pathExists(fixture.expectedLog)).toBe(true)
     expect(organizeRequests).toContain('/api/organize/run')
+  } finally {
+    await fixture.cleanup()
+  }
+})
+
+test('organizes a real EPUB fixture through embedded metadata mode', async ({ page }) => {
+  test.setTimeout(60_000)
+
+  const fixture = await createEmbeddedEPUBFixture()
+  try {
+    const organizeRequests = collectOrganizeRequests(page)
+
+    await loadApp(page)
+    await page.getByRole('textbox', { name: 'Source folder' }).fill(fixture.sourceDir)
+    await page.getByRole('textbox', { name: 'Output folder' }).fill(fixture.outputDir)
+    await page.getByLabel('Metadata source').selectOption('embedded-directory')
+    await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+    await page.getByRole('button', { name: 'Create Dry-run Preview' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Organize preview ready' })).toBeVisible()
+    await expectSummaryValue(page, 'Metadata found', '0')
+    await expectSummaryValue(page, 'Planned moves', '1')
+    await expectSummaryValue(page, 'Warnings', '1')
+    await expect(page.getByText(fixture.expectedDir)).toBeVisible()
+    await expect(page.locator('.warning-list').getByText(fixture.sourceDir)).toBeVisible()
+    await expect.poll(() => pathExists(fixture.expectedFile)).toBe(false)
+    await expect.poll(() => pathExists(fixture.sourceFile)).toBe(true)
+    expect(organizeRequests).toContain('/api/organize/preview')
+
+    await page.getByRole('button', { name: 'Review Preview & Continue' }).click()
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Run Organize will change files')
+      await dialog.accept()
+    })
+    await page.getByRole('button', { name: 'Run Organize' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Organize Run Complete' })).toBeVisible()
+    await expect.poll(() => pathExists(fixture.expectedFile)).toBe(true)
+    await expect.poll(() => pathExists(fixture.sourceFile)).toBe(false)
+    await expect.poll(() => pathExists(fixture.expectedLog)).toBe(true)
+    expect(organizeRequests).toContain('/api/organize/run')
+  } finally {
+    await fixture.cleanup()
+  }
+})
+
+test('uses numbered layout and removes empty source folders after organize run', async ({ page }) => {
+  test.setTimeout(60_000)
+
+  const fixture = await createNumberedLayoutFixture()
+  try {
+    await loadApp(page)
+    await page.getByRole('textbox', { name: 'Source folder' }).fill(fixture.sourceDir)
+    await page.getByRole('textbox', { name: 'Output folder' }).fill(fixture.outputDir)
+    await page.getByLabel('Layout').selectOption('author-series-title-number')
+    await page.getByLabel('Remove empty source folders after run').check()
+    await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+    await page.getByRole('button', { name: 'Create Dry-run Preview' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Organize preview ready' })).toBeVisible()
+    await expectSummaryValue(page, 'Metadata found', '1')
+    await expectSummaryValue(page, 'Planned moves', '1')
+    await expect(page.getByText(fixture.expectedDir)).toBeVisible()
+    await expect.poll(() => pathExists(fixture.expectedFile)).toBe(false)
+    await expect.poll(() => pathExists(fixture.bookDir)).toBe(true)
+
+    await page.getByRole('button', { name: 'Review Preview & Continue' }).click()
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Run Organize will change files')
+      await dialog.accept()
+    })
+    await page.getByRole('button', { name: 'Run Organize' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Organize Run Complete' })).toBeVisible()
+    await expect(page.locator('.review-layout .result-grid strong').filter({ hasText: fixture.expectedLog })).toBeVisible()
+    await expect.poll(() => pathExists(fixture.expectedFile)).toBe(true)
+    await expect.poll(() => pathExists(fixture.expectedLog)).toBe(true)
+    await expect.poll(() => pathExists(fixture.bookDir)).toBe(false)
+  } finally {
+    await fixture.cleanup()
+  }
+})
+
+test('reports real backend path validation errors for organize preview', async ({ page }) => {
+  test.setTimeout(60_000)
+
+  const fixture = await createPathErrorFixture()
+  try {
+    const organizeRequests = collectOrganizeRequests(page)
+
+    await loadApp(page)
+    await page.getByRole('textbox', { name: 'Source folder' }).fill(fixture.missingSourceDir)
+    await page.getByRole('textbox', { name: 'Output folder' }).fill(fixture.outputDir)
+    await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+    await page.getByRole('button', { name: 'Create Dry-run Preview' }).click()
+
+    await expect(page.locator('.inline-alert').filter({ hasText: 'base directory does not exist' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
+    await page.getByRole('button', { name: 'Review Inspect backend results' }).click()
+    await expect(page.locator('.review-layout .error-list').getByText(/Organize preview: .*base directory/)).toBeVisible()
+
+    await page.getByRole('button', { name: 'Configure & Scan Choose workflow inputs' }).click()
+    await page.getByRole('textbox', { name: 'Source folder' }).fill(fixture.sourceDir)
+    await page.getByRole('textbox', { name: 'Output folder' }).fill(fixture.missingOutputDir)
+    await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+    await page.getByRole('button', { name: 'Create Dry-run Preview' }).click()
+
+    await expect(page.locator('.inline-alert').filter({ hasText: 'error resolving output directory path' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
+    expect(organizeRequests.filter((path) => path === '/api/organize/preview')).toHaveLength(2)
   } finally {
     await fixture.cleanup()
   }
@@ -81,6 +194,22 @@ type OrganizeFixture = {
   expectedDir: string
   expectedFile: string
   expectedLog: string
+  cleanup: () => Promise<void>
+}
+
+type EmbeddedEPUBFixture = OrganizeFixture & {
+  sourceFile: string
+}
+
+type NumberedLayoutFixture = OrganizeFixture & {
+  bookDir: string
+}
+
+type PathErrorFixture = {
+  sourceDir: string
+  outputDir: string
+  missingSourceDir: string
+  missingOutputDir: string
   cleanup: () => Promise<void>
 }
 
@@ -119,6 +248,92 @@ async function createOrganizeFixture(): Promise<OrganizeFixture> {
   }
 }
 
+async function createEmbeddedEPUBFixture(): Promise<EmbeddedEPUBFixture> {
+  const root = await mkFixtureRoot()
+  const sourceDir = join(root, 'source')
+  const outputDir = join(root, 'output')
+  const bookDir = join(sourceDir, 'embedded-book')
+  const sourceFile = join(bookDir, 'title-author-series1.epub')
+
+  await mkdir(bookDir, { recursive: true })
+  await mkdir(outputDir, { recursive: true })
+  await copyFile(join(repoRoot, 'testdata', 'epub', 'title-author-series1.epub'), sourceFile)
+
+  const expectedDir = join(outputDir, 'Jeef of Github,Some random guy', 'Test Books', 'First book of testing knowledge')
+  const resolvedOutputDir = await realpath(outputDir)
+
+  return {
+    sourceDir,
+    outputDir,
+    missingDir: '',
+    expectedDir,
+    expectedFile: join(expectedDir, 'title-author-series1.epub'),
+    expectedLog: join(resolvedOutputDir, '.abook-org.log'),
+    sourceFile,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  }
+}
+
+async function createNumberedLayoutFixture(): Promise<NumberedLayoutFixture> {
+  const root = await mkFixtureRoot()
+  const sourceDir = join(root, 'source')
+  const outputDir = join(root, 'output')
+  const bookDir = join(sourceDir, 'numbered-layout-book')
+
+  await mkdir(bookDir, { recursive: true })
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(
+    join(bookDir, 'metadata.json'),
+    JSON.stringify({
+      title: 'Numbered Layout Book',
+      authors: ['Layout Author'],
+      series: ['Layout Series'],
+      series_index: 3,
+    }),
+  )
+  await writeFile(join(bookDir, 'audio.mp3'), 'fake audio data')
+
+  const expectedDir = join(outputDir, 'Layout Author', 'Layout Series', '#3 - Numbered Layout Book')
+  const resolvedOutputDir = await realpath(outputDir)
+
+  return {
+    sourceDir,
+    outputDir,
+    missingDir: '',
+    expectedDir,
+    expectedFile: join(expectedDir, 'audio.mp3'),
+    expectedLog: join(resolvedOutputDir, '.abook-org.log'),
+    bookDir,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  }
+}
+
+async function createPathErrorFixture(): Promise<PathErrorFixture> {
+  const root = await mkFixtureRoot()
+  const sourceDir = join(root, 'source')
+  const outputDir = join(root, 'output')
+  const bookDir = join(sourceDir, 'valid-book')
+
+  await mkdir(bookDir, { recursive: true })
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(
+    join(bookDir, 'metadata.json'),
+    JSON.stringify({
+      title: 'Valid Book',
+      authors: ['Valid Author'],
+    }),
+  )
+  await writeFile(join(bookDir, 'audio.mp3'), 'fake audio data')
+
+  return {
+    sourceDir,
+    outputDir,
+    missingSourceDir: join(root, 'missing-source'),
+    missingOutputDir: join(root, 'missing-output'),
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  }
+}
+
 async function mkFixtureRoot(): Promise<string> {
   return mkdtemp(join(tmpdir(), 'abo-web-organize-'))
 }
@@ -144,6 +359,17 @@ async function loadApp(page: Page): Promise<void> {
   await expect(page.locator('#app')).not.toBeEmpty()
 
   expect(consoleMessages, 'No browser console warnings/errors during initial render').toEqual([])
+}
+
+function collectOrganizeRequests(page: Page): string[] {
+  const organizeRequests: string[] = []
+  page.on('request', (request) => {
+    const url = new URL(request.url())
+    if (url.pathname.startsWith('/api/organize/')) {
+      organizeRequests.push(url.pathname)
+    }
+  })
+  return organizeRequests
 }
 
 async function expectSummaryValue(page: Page, label: string, value: string): Promise<void> {


### PR DESCRIPTION
Resolves #105.\n\nSummary:\n- Expand real organize Playwright coverage for embedded EPUB metadata, numbered layout selection, remove-empty execution, and real backend path validation errors.\n- Assert dry-run does not mutate files, run moves files, source cleanup occurs when requested, and undo logs are created.\n- Update GUI testing docs and changelog coverage notes.\n\nTests:\n- cd web && npm run test:e2e -- --project=chromium-desktop tests/e2e/organize-real.spec.ts\n- make gui-test\n- go test ./internal/app ./internal/server\n- git diff --check\n- prek run --all-files\n- make fmt-check (fails on unrelated ignored local debug Go files: debug_booklist.go, debug_script.go, debug_tui.go, test_debug.go, tui_test.go)