### PR TITLE
Harden web UI gating Playwright coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Embedded EPUB ABS coverage**: Added Docker-backed already-indexed EPUB current-behavior coverage for embedded metadata workflows.
 - **ABS browser UI coverage**: Added Docker-backed Playwright coverage for the web Audiobookshelf setup and operation controls against real ABS instances.
 - **Organize browser coverage**: Expanded real Playwright coverage for embedded EPUB metadata, numbered layouts, remove-empty execution, dry-run behavior, undo-log creation, and real backend path validation errors.
+- **Web UI gating coverage**: Hardened Playwright checks for organize confirmation cancellation, failed preview lockouts, retry recovery, and ABS cleanup acknowledgement gating.
 - **ABS metadata organization**: Added `audiobook-organizer abs organize` so already-indexed Audiobookshelf items can be reorganized with ABS API metadata while reusing the normal organizer move, dry-run, undo, layout, logging, and scan follow-up flow.
 - **Text-only metadata inspection**: `audiobook-organizer metadata` now prints non-interactive metadata scan results, `metadata --json` writes machine-readable output, and `metadata-tui` keeps the old interactive metadata exploration workflow explicit.
 

--- a/docs/GUI_TESTING.md
+++ b/docs/GUI_TESTING.md
@@ -83,7 +83,8 @@ The current suite covers:
   session token.
 - The dashboard renders without browser console warnings or errors.
 - Workflow navigation, backend bootstrap state, folder picker/drop behavior,
-  narrow viewport overflow checks, and bootstrap fallback states.
+  narrow viewport overflow checks, bootstrap fallback states, failed-preview
+  gating, confirmation cancel behavior, and recovery after corrected input.
 - Real organize preview and execution against temporary filesystem fixtures,
   including `metadata.json`, embedded EPUB metadata, numbered layout selection,
   remove-empty execution, dry-run immutability, undo-log creation, and backend
@@ -96,6 +97,9 @@ The current suite covers:
   harness, including URL/token entry, library discovery, path mapping
   validation, metadata-item loading, library-state loading, scan triggering,
   destructive cleanup gating, and missing-item cleanup.
+- Supplemental browser contract checks for ABS cleanup acknowledgement gating
+  and failed organize, rename, and ABS requests that must not unlock mutation
+  actions.
 
 ## Expansion Plan
 

--- a/web/tests/e2e/gui-smoke.spec.ts
+++ b/web/tests/e2e/gui-smoke.spec.ts
@@ -378,6 +378,7 @@ test('contracts ABS operation controls with mocked backend responses', async ({ 
   expect(scanBody?.config).toEqual(expect.objectContaining({ library_id: 'lib-audio' }))
 
   await expect(page.getByRole('button', { name: 'Clean Missing Items' })).toBeDisabled()
+  expect(cleanBody).toBeUndefined()
   await page.getByLabel('I understand this removes ABS missing item records').check()
   page.once('dialog', async (dialog) => {
     expect(dialog.message()).toContain('Clean missing ABS item records')
@@ -493,12 +494,18 @@ test('contracts organize preview and run UI state with mocked backend responses'
 })
 
 test('keeps organize run locked when preview fails', async ({ page }) => {
+  let runRequested = false
+
   await page.route('**/api/organize/preview', async (route) => {
     await route.fulfill({
       status: 400,
       contentType: 'application/json',
       body: JSON.stringify({ error: 'preview exploded' }),
     })
+  })
+  await page.route('**/api/organize/run', async (route) => {
+    runRequested = true
+    await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'run leaked' }) })
   })
 
   await loadApp(page)
@@ -512,6 +519,7 @@ test('keeps organize run locked when preview fails', async ({ page }) => {
   await page.getByRole('button', { name: 'Review Inspect backend results' }).click()
   await expect(page.getByRole('heading', { name: 'Organize Results Need Attention' })).toBeVisible()
   await expect(page.locator('.review-layout .error-list').getByText('Organize preview: preview exploded')).toBeVisible()
+  expect(runRequested).toBe(false)
 })
 
 test('contracts rename preview UI state with mocked backend responses', async ({ page }) => {
@@ -589,12 +597,18 @@ test('contracts rename preview UI state with mocked backend responses', async ({
 })
 
 test('keeps rename run unavailable when preview fails', async ({ page }) => {
+  let runRequested = false
+
   await page.route('**/api/rename/preview', async (route) => {
     await route.fulfill({
       status: 400,
       contentType: 'application/json',
       body: JSON.stringify({ error: 'rename preview exploded' }),
     })
+  })
+  await page.route('**/api/rename/run', async (route) => {
+    runRequested = true
+    await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'run leaked' }) })
   })
 
   await loadApp(page)
@@ -610,6 +624,7 @@ test('keeps rename run unavailable when preview fails', async ({ page }) => {
   await expect(
     page.locator('.review-layout .error-list').getByText('Rename preview: rename preview exploded'),
   ).toBeVisible()
+  expect(runRequested).toBe(false)
 })
 
 test('separates workflow modes and gates run behind preview review', async ({ page }) => {

--- a/web/tests/e2e/organize-real.spec.ts
+++ b/web/tests/e2e/organize-real.spec.ts
@@ -21,13 +21,7 @@ test('runs organize preview and execution against real filesystem fixtures', asy
 
   const fixture = await createOrganizeFixture()
   try {
-    const organizeRequests: string[] = []
-    page.on('request', (request) => {
-      const url = new URL(request.url())
-      if (url.pathname.startsWith('/api/organize/')) {
-        organizeRequests.push(url.pathname)
-      }
-    })
+    const organizeRequests = collectOrganizeRequests(page)
 
     await loadApp(page)
     await page.getByRole('textbox', { name: 'Source folder' }).fill(fixture.sourceDir)
@@ -50,6 +44,16 @@ test('runs organize preview and execution against real filesystem fixtures', asy
     await page.getByRole('button', { name: 'Review Preview & Continue' }).click()
     await expect(page.getByRole('heading', { name: 'Execute the reviewed plan' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Run Organize' })).toBeEnabled()
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Run Organize will change files')
+      await dialog.dismiss()
+    })
+    await page.getByRole('button', { name: 'Run Organize' }).click()
+    await expect(page.getByRole('heading', { name: 'Execute the reviewed plan' })).toBeVisible()
+    await expect.poll(() => pathExists(fixture.expectedFile)).toBe(false)
+    await expect(page.locator('.event-row').filter({ hasText: 'Request started: Organize run' })).toHaveCount(0)
+    expect(organizeRequests).not.toContain('/api/organize/run')
 
     page.once('dialog', async (dialog) => {
       expect(dialog.message()).toContain('Run Organize will change files')
@@ -181,7 +185,17 @@ test('reports real backend path validation errors for organize preview', async (
 
     await expect(page.locator('.inline-alert').filter({ hasText: 'error resolving output directory path' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
-    expect(organizeRequests.filter((path) => path === '/api/organize/preview')).toHaveLength(2)
+
+    await page.getByRole('button', { name: 'Configure & Scan Choose workflow inputs' }).click()
+    await page.getByRole('textbox', { name: 'Output folder' }).fill(fixture.outputDir)
+    await page.getByRole('button', { name: 'Preview Review dry-run output' }).click()
+    await page.getByRole('button', { name: 'Create Dry-run Preview' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Organize preview ready' })).toBeVisible()
+    await expect(page.locator('.inline-alert')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Run Execute after review' })).toBeDisabled()
+    await expect.poll(() => pathExists(fixture.expectedFile)).toBe(false)
+    expect(organizeRequests.filter((path) => path === '/api/organize/preview')).toHaveLength(3)
   } finally {
     await fixture.cleanup()
   }
@@ -208,6 +222,7 @@ type NumberedLayoutFixture = OrganizeFixture & {
 type PathErrorFixture = {
   sourceDir: string
   outputDir: string
+  expectedFile: string
   missingSourceDir: string
   missingOutputDir: string
   cleanup: () => Promise<void>
@@ -328,6 +343,7 @@ async function createPathErrorFixture(): Promise<PathErrorFixture> {
   return {
     sourceDir,
     outputDir,
+    expectedFile: join(outputDir, 'Valid Author', 'Valid Book', 'audio.mp3'),
     missingSourceDir: join(root, 'missing-source'),
     missingOutputDir: join(root, 'missing-output'),
     cleanup: () => rm(root, { recursive: true, force: true }),


### PR DESCRIPTION
Resolves #103.\n\nSummary:\n- Add real organize confirmation-cancel coverage proving dismissed confirmation does not call run or mutate files.\n- Extend real organize path-error coverage to recover after corrected input without stale errors or mutation.\n- Tighten supplemental mocked failure checks so failed organize/rename previews do not leak run requests and ABS cleanup is not requested before acknowledgement.\n- Update GUI testing docs and changelog coverage notes.\n\nTests:\n- cd web && npm run test:e2e -- --project=chromium-desktop tests/e2e/organize-real.spec.ts tests/e2e/gui-smoke.spec.ts\n- make gui-test\n- go test ./internal/app ./internal/server\n- git diff --check\n- prek run --all-files\n- make fmt-check (fails on unrelated ignored local debug Go files: debug_booklist.go, debug_script.go, debug_tui.go, test_debug.go, tui_test.go)