### PR TITLE
docs: add workflow closeout approval mode

### DIFF
--- a/.agents/skills/abo-pr-create/SKILL.md
+++ b/.agents/skills/abo-pr-create/SKILL.md
@@ -17,6 +17,7 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 - Do not create PRs from branches without an appropriate work-type prefix: `feature/`, `fix/`, `docs/`, or `chore/`.
 - Do not include unrelated dirty worktree changes.
 - Do not create the PR with failing required checks unless the user explicitly accepts that status.
+- Honor the closeout approval mode selected during `$abo-workflow`. If no mode was selected, ask before pushing, opening a PR, or enabling auto-merge.
 
 ## Workflow
 
@@ -28,9 +29,10 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 6. Re-check `git status --short --branch` before committing, and do not commit from `master`.
 7. Commit with a concise message tied to the issue.
 8. Re-check `git status --short --branch` before pushing, and do not push directly to `master`.
-9. Push the branch and set upstream.
-10. Create a PR with `gh pr create --base master --head <branch> --body-file <file>`.
-11. Verify the PR URL, target branch, and initial check/review state before reporting success.
-12. If the PR is intentionally ready for merge, do not leave it as a draft. Protected `master` requires passing checks before merge; enable auto-merge when the PR is otherwise ready.
+9. If closeout approval was not already granted, ask before external closeout actions.
+10. Push the branch and set upstream.
+11. Create a PR with `gh pr create --base master --head <branch> --body-file <file>`.
+12. Verify the PR URL, target branch, and initial check/review state before reporting success.
+13. If the PR is intentionally ready for merge, do not leave it as a draft. Protected `master` requires passing checks before merge; enable auto-merge when the PR is otherwise ready and the selected closeout approval mode allows it.
 
 End with the PR URL, tests run, and any checks still pending.

--- a/.agents/skills/abo-workflow/SKILL.md
+++ b/.agents/skills/abo-workflow/SKILL.md
@@ -20,6 +20,18 @@ When the user asks to start, pick, or work through repository issues but does no
 
 If they choose existing issues, inspect open issues first and help pick one before creating a branch or worktree. If they choose new work, capture the goal, motivation, and acceptance criteria before creating the issue and branch.
 
+## Closeout Approval Mode
+
+At the start of tracked feature, fix, docs, chore, or test work, ask the user which closeout mode they want for that issue:
+
+- **Autonomous closeout**: after implementation and verification, the agent may post issue updates, draft PR body files, push the issue branch, open the PR, and enable auto-merge when checks are green.
+- **Checkpoint closeout**: the agent must stop for user approval before posting issue updates, pushing branches, opening PRs, or enabling auto-merge.
+- **Implementation only**: the agent should implement and verify locally, then stop before any GitHub updates or branch pushes.
+
+Record the selected mode in the working notes for the task and carry it into `$abo-pr`, `$abo-pr-create`, `$abo-pr-watcher`, and `$abo-issue-closeout`. If no mode was selected earlier, ask before the first external closeout action.
+
+This mode does not bypass sandbox, network, or destructive-command approvals. When the selected mode authorizes external closeout actions, use it to make one broad, early approval request where possible instead of interrupting at each routine PR-body, push, issue-comment, or PR creation step.
+
 ## Route
 
 - New tracked work or branch setup: `$abo-issue-create`.


### PR DESCRIPTION
Resolves #115

## Summary
- document that PR creation closeout can proceed without a separate confirmation when the maintainer explicitly asks for automatic closeout
- route explicit closeout requests through the PR workflow coordinator

## Tests
- `prek run --all-files`
- `git diff --check origin/master...origin/chore/workflow-closeout-approval`

## Docs/changelog
- Repo-local skill documentation updated.
- Changelog not updated because this is maintainer workflow documentation only, not user-facing application behavior.

## Follow-up
- None.
