### PR TITLE
Add layout template reference command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Web UI gating coverage**: Hardened Playwright checks for organize confirmation cancellation, failed preview lockouts, retry recovery, and ABS cleanup acknowledgement gating.
 - **ABS metadata organization**: Added `audiobook-organizer abs organize` so already-indexed Audiobookshelf items can be reorganized with ABS API metadata while reusing the normal organizer move, dry-run, undo, layout, logging, and scan follow-up flow.
 - **Custom organization layout templates**: Added `--layout-template` and web UI support for template-driven directory layouts such as `{author}/{series}/{series-count} - {title} ({narrator})`.
+- **Layout template CLI help**: Added `audiobook-organizer layout-template` for an in-terminal field reference, fallback syntax, examples, and path safety rules.
 - **Text-only metadata inspection**: `audiobook-organizer metadata` now prints non-interactive metadata scan results, `metadata --json` writes machine-readable output, and `metadata-tui` keeps the old interactive metadata exploration workflow explicit.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Common organization flags:
 | `--flat` | Process files individually; also enables embedded metadata |
 | `--remove-empty` | Remove empty source directories after moving |
 | `--skip-errors` | Continue past missing or invalid metadata |
-| `--layout-template` | Custom directory layout template overriding `--layout` |
+| `--layout-template` | Custom directory layout template overriding `--layout`; see `audiobook-organizer layout-template` |
 | `--author-fields`, `--title-field`, `--series-field`, `--track-field`, `--disc-field` | Field mapping overrides |
 
 See [docs/CLI.md](docs/CLI.md) for the full CLI reference.
@@ -169,6 +169,7 @@ audiobook-organizer rename-tui --dir=/path/to/books
 Template help:
 
 ```bash
+audiobook-organizer layout-template
 audiobook-organizer rename help-template
 ```
 
@@ -296,7 +297,7 @@ audiobook-organizer \
   --layout-template="{author}/{series}/{series-count} - {title} ({narrator})"
 ```
 
-See [docs/LAYOUTS.md](docs/LAYOUTS.md).
+Run `audiobook-organizer layout-template` for the in-terminal field reference, or see [docs/LAYOUTS.md](docs/LAYOUTS.md).
 
 ## Configuration
 

--- a/cmd/abs.go
+++ b/cmd/abs.go
@@ -174,7 +174,7 @@ func addABSOrganizeFlags() {
 	absOrganizeCmd.Flags().
 		StringVarP(&layout, "layout", "l", "author-series-title", "Directory structure layout:\n  - author-series-title:        Author/Series/Title/ (default)\n  - author-series-title-number: Author/Series/#1 - Title/ (include series number in title)\n  - author-title:               Author/Title/ (ignore series)\n  - author-only:                Author/ (flatten all books)")
 	absOrganizeCmd.Flags().
-		StringVar(&layoutTemplate, "layout-template", "", "Custom directory layout template overriding --layout (e.g. \"{author}/{series}/{series-count} - {title}\")")
+		StringVar(&layoutTemplate, "layout-template", "", "Custom directory layout template overriding --layout; see \"audiobook-organizer layout-template\"")
 }
 
 func runABSScan(cmd *cobra.Command, args []string) error {

--- a/cmd/layout_template.go
+++ b/cmd/layout_template.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var layoutTemplateCmd = &cobra.Command{
+	Use:   "layout-template",
+	Short: "Show custom layout template field reference",
+	Long: `Display detailed information about custom organization layout templates.
+
+Use this command to see available fields, fallback syntax, examples, and
+directory path safety rules for the --layout-template flag.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Fprint(cmd.OutOrStdout(), layoutTemplateHelpText())
+	},
+}
+
+func layoutTemplateHelpText() string {
+	return `Audiobook Layout Template Field Reference
+
+USAGE
+  audiobook-organizer --dir=/books --out=/organized \
+    --layout-template="{author}/{series|Standalone}/{series-count} - {title}"
+
+PLACEHOLDER SYNTAX
+  {field}              Render a metadata field
+  ${field}             Alternate field syntax
+  {field|Fallback}     Use fallback text when the field is missing or empty
+
+COMMON FIELDS
+  {author}             First author, formatted with the organizer author format
+  {authors}            All authors, comma-separated
+  {title}              Book title
+  {series}             Series name without number
+  {series_full}        Series name with number when available
+  {series_number}      Series number only, such as 1 or 2.5
+  {series-count}       Alias for {series_number}
+  {album}              Album field from audio metadata
+  {track}              Track number, zero-padded to two digits
+  {year}               Publication year from raw metadata
+  {narrator}           First narrator or narrator value when available
+  {narrators}          All narrators, comma-separated when available
+
+RAW METADATA FIELDS
+  Templates can also reference raw metadata keys. Dashes are normalized to
+  underscores, so {publisher-name} can read a raw field named publisher_name.
+
+EXAMPLES
+  Author / Series / Number - Title
+    {author}/{series}/{series-count} - {title}
+
+  Standalone fallback for books without a series
+    {author}/{series|Standalone}/{title}
+
+  Include narrator in the book folder
+    {author}/{series|Standalone}/{series-count} - {title} ({narrator|Unknown Narrator})
+
+PATH SAFETY
+  Slashes in the template create directories. Metadata values are sanitized
+  inside each path segment, so slashes or unsafe characters in metadata cannot
+  create extra directories.
+
+  Absolute templates and "." or ".." path segments are rejected.
+
+MORE DOCS
+  docs/LAYOUTS.md
+`
+}
+
+func init() {
+	rootCmd.AddCommand(layoutTemplateCmd)
+}

--- a/cmd/layout_template_test.go
+++ b/cmd/layout_template_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
 func TestRootCommandIncludesLayoutTemplateFlag(t *testing.T) {
 	flag := rootCmd.Flags().Lookup("layout-template")
@@ -23,6 +27,51 @@ func TestRootCommandIncludesLayoutTemplateFlag(t *testing.T) {
 			"second layout-template alias = %q, want AUDIOBOOK_ORGANIZER_LAYOUT_TEMPLATE",
 			aliases[1],
 		)
+	}
+}
+
+func TestRootCommandIncludesLayoutTemplateHelpCommand(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"layout-template"})
+	if err != nil {
+		t.Fatalf("Find(layout-template) error = %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("root command missing layout-template help command")
+	}
+	if cmd.Use != "layout-template" {
+		t.Errorf("layout-template command Use = %q, want layout-template", cmd.Use)
+	}
+}
+
+func TestLayoutTemplateCommandOutputCoversFieldsAndSafety(t *testing.T) {
+	var output bytes.Buffer
+	layoutTemplateCmd.SetOut(&output)
+	t.Cleanup(func() {
+		layoutTemplateCmd.SetOut(nil)
+	})
+
+	layoutTemplateCmd.Run(layoutTemplateCmd, nil)
+
+	got := output.String()
+	for _, want := range []string{
+		"{author}",
+		"{series-count}",
+		"{narrators}",
+		"{publisher-name}",
+		"{series|Standalone}",
+		"${field}",
+		"Absolute templates",
+		"docs/LAYOUTS.md",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("layout-template output missing %q", want)
+		}
+	}
+}
+
+func TestLayoutTemplateCommandSuppressesStartupBanner(t *testing.T) {
+	if shouldPrintStartupBanner([]string{"layout-template"}) {
+		t.Fatal("layout-template reference command should suppress startup banner")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -206,7 +206,7 @@ func Execute() error {
 
 func shouldPrintStartupBanner(args []string) bool {
 	for _, arg := range args {
-		if arg == "metadata" {
+		if arg == "metadata" || arg == "layout-template" {
 			return false
 		}
 	}
@@ -278,7 +278,7 @@ func init() {
 	rootCmd.Flags().
 		StringVarP(&layout, "layout", "l", "author-series-title", "Directory structure layout:\n  - author-series-title:        Author/Series/Title/ (default)\n  - author-series-title-number: Author/Series/#1 - Title/ (include series number in title)\n  - author-title:               Author/Title/ (ignore series)\n  - author-only:                Author/ (flatten all books)")
 	rootCmd.Flags().
-		StringVar(&layoutTemplate, "layout-template", "", "Custom directory layout template overriding --layout (e.g. \"{author}/{series}/{series-count} - {title}\")")
+		StringVar(&layoutTemplate, "layout-template", "", "Custom directory layout template overriding --layout; see \"audiobook-organizer layout-template\"")
 
 	// Field mapping flags (persistent for all commands)
 	rootCmd.PersistentFlags().

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -201,6 +201,12 @@ audiobook-organizer \
   --layout-template="{author}/{series}/{series-count} - {title} ({narrator})"
 ```
 
+Show the available layout template fields and syntax:
+
+```bash
+audiobook-organizer layout-template
+```
+
 **Replace spaces with underscores:**
 ```bash
 audiobook-organizer \

--- a/docs/LAYOUTS.md
+++ b/docs/LAYOUTS.md
@@ -75,6 +75,12 @@ Brandon Sanderson/
 
 Use `--layout-template` when the fixed layout names do not describe the folder structure you want. A custom template overrides `--layout`.
 
+For an in-terminal reference of fields, fallback syntax, examples, and path safety rules, run:
+
+```bash
+audiobook-organizer layout-template
+```
+
 ```bash
 audiobook-organizer \
   --dir=/books \
@@ -89,9 +95,14 @@ Template fields use the same renderer as rename templates. Both `{field}` and `$
 | `{author}` | `N. K. Jemisin` |
 | `{title}` | `The Obelisk Gate` |
 | `{series}` | `The Broken Earth` |
+| `{series_full}` | `The Broken Earth #2` |
 | `{series_number}` or `{series-count}` | `2` |
+| `{album}` | `The Broken Earth` |
+| `{track}` | `01` |
 | `{narrator}` or `{narrators}` | `Robin Miles` |
 | `{year}` | `2016` |
+
+Templates can also reference raw metadata keys. Dashes are normalized to underscores, so `{publisher-name}` can read a raw `publisher_name` field.
 
 Each path segment is rendered and sanitized independently, so slashes or other unsafe characters in metadata values cannot create extra directories. Absolute templates and `.` or `..` path segments are rejected.
 


### PR DESCRIPTION
Resolves #118

## Summary
- Add `audiobook-organizer layout-template` as a root-level CLI reference for custom layout templates.
- Point `--layout-template` help text to the new reference command for both normal organize and `abs organize`.
- Document the command in README, CLI docs, and layout docs, including raw metadata fields and path safety behavior.

## Tests
- `go test ./cmd -run 'TestRootCommandIncludesLayoutTemplate|TestLayoutTemplate|TestShouldPrintStartupBanner'`
- `go test ./cmd ./internal/organizer`
- `go test ./...`
- `go run . layout-template`
- `make lint`
- `git diff --check`
- `prek run --all-files`

## Docs / Changelog
- Updated `README.md`, `docs/CLI.md`, and `docs/LAYOUTS.md`.
- Added an Unreleased changelog entry.

## Follow-up
- After this merges, cut a release and comment on #47 with the release link and commands to try the custom layout workflow.
