### PR TITLE
Fix stable release GoReleaser command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,14 +157,16 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Run GoReleaser to create archives and release (skip build since we have pre-built binaries)
+      # Run GoReleaser to create archives, packages, checksums, and the GitHub release.
+      # The platform build jobs above validate each target first; this final job
+      # performs the publishing release build from the tag commit.
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v7
         timeout-minutes: 10
         with:
           distribution: goreleaser
           version: latest
-          args: continue --merge
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Beta release tags now derive from the latest stable SemVer tag instead of stacking beta suffixes from prior prereleases.
 - Frontend embed path is now stable for goreleaser by building into `internal/server/static`.
 - Release workflows build the web frontend before packaging the single binary.
+- Stable release publishing now uses the supported GoReleaser release command.
 - Organize summaries now report directories missing metadata even when verbose console logging is disabled, so web previews show real warning counts.
 - Rename previews now report skipped files, extraction errors, and duplicate target conflicts in backend summaries used by the web UI.
 - Web activity and review panels now show real request lifecycle events, completed backend summaries, persistent warnings/errors, and undo-log guidance only when a backend log path exists.


### PR DESCRIPTION
Resolves #120

## Summary
- Replace the stable release workflow's unsupported `goreleaser continue --merge` invocation with `goreleaser release --clean`.
- Clarify that the platform build jobs validate targets before the final publish job performs the release build.
- Add a changelog entry for the release workflow fix.

## Tests
- `go run github.com/goreleaser/goreleaser/v2@v2.15.4 check`
- `git diff --check`
- `prek run --all-files`

## Follow-up
- Move the failed `v0.12.0` tag to the fixed master commit and rerun the Release workflow.
