### PR TITLE
Link layout-template help to hosted docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `audiobook-organizer layout-template` now points to the hosted GitHub layout guide so installed binaries show a usable docs link.
 - Removed the deprecated GUI tree and release packaging. Releases now focus on one `audiobook-organizer` binary with CLI, TUI, ABS, and local web UI entrypoints.
 - Improved the README overview, repository metadata, and web page metadata so search results describe the project as an audiobook organizer and renamer for Audiobookshelf with `metadata.json`, EPUB, MP3, and M4B support.
 - Rewrote the root README for the single-binary web UI direction and current command surface.

--- a/cmd/layout_template.go
+++ b/cmd/layout_template.go
@@ -66,7 +66,7 @@ PATH SAFETY
   Absolute templates and "." or ".." path segments are rejected.
 
 MORE DOCS
-  docs/LAYOUTS.md
+  https://github.com/jeeftor/audiobook-organizer/blob/master/docs/LAYOUTS.md
 `
 }
 

--- a/cmd/layout_template_test.go
+++ b/cmd/layout_template_test.go
@@ -61,11 +61,14 @@ func TestLayoutTemplateCommandOutputCoversFieldsAndSafety(t *testing.T) {
 		"{series|Standalone}",
 		"${field}",
 		"Absolute templates",
-		"docs/LAYOUTS.md",
+		"https://github.com/jeeftor/audiobook-organizer/blob/master/docs/LAYOUTS.md",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("layout-template output missing %q", want)
 		}
+	}
+	if strings.Contains(got, "\n  docs/LAYOUTS.md\n") {
+		t.Error("layout-template output still uses only the local docs path")
 	}
 }
 


### PR DESCRIPTION
Resolves #122

## Summary
- Update `audiobook-organizer layout-template` so MORE DOCS points to the hosted GitHub layout guide.
- Cover the hosted URL in the focused command-output test and reject the local-only docs path.
- Add an Unreleased changelog entry for the CLI help improvement.

## Tests
- `go test ./cmd`
- `go run main.go layout-template`
- `make test-unit`
- `make fmt-check`
- `make lint` (rerun with normal Go build-cache access after sandbox cache permission failure)
- `prek run --all-files`

## Docs / Changelog / ABS
- Changelog: updated `CHANGELOG.md` under Unreleased.
- Docs: packaged CLI help now links to the hosted existing docs.
- ABS matrix: not applicable; this is CLI help text only.

## Follow-up
- None.