### PR TITLE
Fix Docker release image Go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Docker image publishing now builds with Go 1.25 so release tags match the toolchain required by `go.mod`.
 - Beta release tags now derive from the latest stable SemVer tag instead of stacking beta suffixes from prior prereleases.
 - Frontend embed path is now stable for goreleaser by building into `internal/server/static`.
 - Release workflows build the web frontend before packaging the single binary.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Resolves #124

## Summary
- Update the Dockerfile builder image to `golang:1.25-alpine` so Docker release builds match the Go version required by `go.mod`.
- Add an Unreleased changelog entry for the Docker publish fix.

## Tests
- `docker build --platform linux/amd64 -t audiobook-organizer:codex-docker-go-version .`
- `docker run --rm audiobook-organizer:codex-docker-go-version version` (reported `Go: go1.25.10`)
- `make fmt-check`
- `prek run --all-files`

## Docs / Changelog / ABS
- Changelog: updated `CHANGELOG.md` under Unreleased.
- Docs: no separate docs needed; this is release infrastructure behavior.
- ABS matrix: not applicable; no ABS-facing behavior changed.

## Follow-up
- After merge, tag `v0.12.2` to republish the release and rerun Docker image publishing with the corrected toolchain.