### PR TITLE
Clarify closeout rules for user-created issues

### DIFF
--- a/.agents/skills/abo-issue-closeout/SKILL.md
+++ b/.agents/skills/abo-issue-closeout/SKILL.md
@@ -17,12 +17,14 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, `references/abo-assistan
 2. Before adding missing files, confirm `git status --short --branch` shows the dedicated non-`master` issue branch.
 3. Add missing `CHANGELOG.md`, docs, or `test/abs/test-matrix.md` updates when required.
 4. Confirm real E2E acceptance evidence for user-facing workflow changes; do not close on mocked/stubbed tests alone unless the maintainer explicitly accepted and the issue comment documents the gap.
-5. Comment on the issue with what changed, tests run, and any follow-up work.
-6. If a PR will close the issue, ensure the PR body uses `Resolves #<issue>` and do not manually close it.
-7. Treat the issue as open until the resolving PR is ready, required checks pass, auto-merge is enabled or the PR has merged back into `master`, and the linked issue has closed.
-8. After merge, confirm the linked issue closed and the feature branch or worktree was cleaned up. Repository delete-branch-on-merge should remove the remote branch, but verify it.
-9. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, or the work intentionally completed without a PR.
-10. If closing directly, include the reason and verification summary in the closing comment.
-11. After issue closeout, follow `references/abo-assistant/common.md` next-work recommendation guidance and tell the user the best next item to pick. Do not start the next item unless the user asks.
+5. Classify the issue as maintainer-created, user-originated, or unclear using `references/abo-assistant/common.md`.
+6. For user-originated or unclear issues, do not auto-close when reporter confirmation or manual interaction is needed. Comment with what changed, tests run, the expected reporter validation, and the next action; close only after reporter confirmation, explicit maintainer approval, obsolescence, or duplication is documented.
+7. Comment on the issue with what changed, tests run, and any follow-up work.
+8. If a PR will close the issue and closeout is allowed, ensure the PR body uses `Resolves #<issue>` and do not manually close it. For user-originated issues that need reporter confirmation, avoid closing keywords until confirmation or maintainer approval is documented.
+9. Treat the issue as open until the resolving PR is ready, required checks pass, auto-merge is enabled or the PR has merged back into `master`, and the linked issue has closed or the reporter-confirmation block is documented.
+10. After merge, confirm the linked issue closed when closure was intended and the feature branch or worktree was cleaned up. Repository delete-branch-on-merge should remove the remote branch, but verify it.
+11. Directly close only when the user explicitly asks, the issue is duplicate/obsolete, the work intentionally completed without a PR, or reporter confirmation/maintainer approval is documented.
+12. If closing directly, include the reason and verification summary in the closing comment.
+13. After issue closeout, follow `references/abo-assistant/common.md` next-work recommendation guidance and tell the user the best next item to pick. Do not start the next item unless the user asks.
 
 Do not close an issue with failing or unrun required checks unless the user explicitly accepts the risk and the reason is documented.

--- a/.agents/skills/abo-issue-verify/SKILL.md
+++ b/.agents/skills/abo-issue-verify/SKILL.md
@@ -14,14 +14,16 @@ Read `AGENTS.md`, `references/abo-assistant/common.md`, and `references/abo-assi
 ## Workflow
 
 1. Identify the issue and read its body/comments.
-2. Extract acceptance criteria and any follow-up decisions recorded during implementation.
-3. Inspect the branch diff against `master`.
-4. Verify each criterion against code, tests, docs, and behavior.
-5. Check whether `CHANGELOG.md` is required and present.
-6. Check whether `test/abs/test-matrix.md` is required and present for ABS-facing changes.
-7. For user-facing workflow changes, verify that real E2E acceptance coverage exists and was run; classify mocked/stubbed UI or API tests as supplemental only.
-8. Run or confirm the narrowest relevant verification commands, widening when practical.
-9. Verify whether the work is only locally complete or fully closed out through a PR merge back into `master`.
-10. Report a checklist of pass/fail/blocked items and the exact remaining work.
+2. Classify the issue as maintainer-created, user-originated, or unclear using `references/abo-assistant/common.md`.
+3. Extract acceptance criteria and any follow-up decisions recorded during implementation.
+4. Inspect the branch diff against `master`.
+5. Verify each criterion against code, tests, docs, and behavior.
+6. Check whether `CHANGELOG.md` is required and present.
+7. Check whether `test/abs/test-matrix.md` is required and present for ABS-facing changes.
+8. For user-facing workflow changes, verify that real E2E acceptance coverage exists and was run; classify mocked/stubbed UI or API tests as supplemental only.
+9. For user-originated or unclear issues, determine whether repo-native verification fully proves the fix. If reporter confirmation or manual interaction is needed, mark closeout blocked until confirmation, maintainer approval, or documented obsolescence/duplication.
+10. Run or confirm the narrowest relevant verification commands, widening when practical.
+11. Verify whether the work is only locally complete or fully closed out through a PR merge back into `master`.
+12. Report a checklist of pass/fail/blocked items and the exact remaining work.
 
 Do not mark the issue done just because tests pass. Tie completion back to acceptance criteria and repo workflow obligations.

--- a/.agents/skills/abo-issue-watcher/SKILL.md
+++ b/.agents/skills/abo-issue-watcher/SKILL.md
@@ -15,10 +15,11 @@ Read `AGENTS.md` and `references/abo-assistant/common.md`.
 
 1. Identify the issue from the prompt, branch, PR body, or recent GitHub context.
 2. Inspect title, body, labels, state, assignees, comments, linked PRs, and references.
-3. Summarize acceptance criteria, current status, blockers, and next actions.
-4. If work is in progress, compare issue scope with the current branch diff.
-5. Add an issue comment only when the user asks or when repository workflow requires a meaningful update.
-6. Do not close the issue; route closeout through `$abo-issue-closeout`.
+3. Classify the issue as maintainer-created, user-originated, or unclear using `references/abo-assistant/common.md`; note whether external reporter confirmation or manual interaction is needed before closeout.
+4. Summarize acceptance criteria, current status, blockers, and next actions.
+5. If work is in progress, compare issue scope with the current branch diff.
+6. Add an issue comment only when the user asks or when repository workflow requires a meaningful update.
+7. Do not close the issue; route closeout through `$abo-issue-closeout`.
 
 ## Issue Comments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented browser binary setup for local web UI E2E checks, including Playwright-managed Chromium and cached Chrome Headless Shell fallback behavior.
 - Clarified maintainer workflow guidance so user-facing workflow issues require real E2E acceptance evidence, while mocked UI/API tests remain supplemental.
 - Clarified repo-local agent closeout guidance so completed tracked work ends with a next-work recommendation based on open issues and dependency context.
+- Clarified issue and PR closeout guidance for user-originated reports that require reporter confirmation or manual validation.
 - Restructured the local web UI into explicit organize, rename, and Audiobookshelf workflow stages so configure, dry-run preview, run, and review states are separated.
 - Improved local web UI startup handling so config/options loading and fallback states are visible and Audiobookshelf metadata mode stays scoped to the ABS workflow.
 - Wired the local web UI organize workflow to real preview and run endpoints with review gating and backend result summaries.

--- a/references/abo-assistant/common.md
+++ b/references/abo-assistant/common.md
@@ -22,6 +22,16 @@ Use this shared reference for Audiobook Organizer repo-local skills.
 - Do not treat a local commit or draft PR as done. Finish the cycle by getting the PR ready, passing required checks, enabling or completing merge back into `master`, confirming the linked issue closed, and cleaning up the branch or worktree.
 - After tracked work is complete, suggest the next useful work item before ending the final response. Base the suggestion on current open issues, parent/child dependencies, recently completed workflow chains, and any follow-up issues created during the work. Do not start the next task unless the user asks.
 
+## Issue Origin
+
+Classify issue origin before verification and closeout:
+
+- **Maintainer-created issue**: opened by the repository maintainer or created by the agent on behalf of the maintainer in the current workflow. These may close automatically through a resolving PR when acceptance criteria, checks, docs, changelog, and branch hygiene are satisfied.
+- **User-originated issue**: opened by an external reporter, or materially updated by an external reporter with reproduction details, acceptance expectations, or manual validation needs. These need a documented reporter-confirmation path before closeout when the fix cannot be fully validated by repo-native automated or real E2E checks.
+- **Unclear origin**: if the author/context is ambiguous, treat it as user-originated for closeout and ask for maintainer guidance before closing.
+
+For user-originated issues that need reporter confirmation or manual interaction, do not auto-close solely because a PR merged. Leave a comment with the verification performed, the expected reporter validation, and the next action. Close only after reporter confirmation, maintainer approval to close without it, or a documented reason the report is obsolete or duplicate.
+
 ## Next Work Recommendation
 
 When a feature, fix, docs, test, or chore issue is finished through PR merge or explicit issue closeout:

--- a/references/abo-assistant/pr.md
+++ b/references/abo-assistant/pr.md
@@ -7,9 +7,11 @@ Use this shared reference for PR writing, creation, watching, and closeout.
 - Branch is not `master`, `main`, `develop`, or `dev`.
 - Branch uses the appropriate work-type prefix: `feature/`, `fix/`, `docs/`, or `chore/`.
 - Branch is tied to a GitHub issue.
+- Issue origin has been classified as maintainer-created, user-originated, or unclear using `references/abo-assistant/common.md`.
 - Unrelated dirty worktree changes are not included.
 - Relevant tests, lint, and builds have been run or explicitly documented as blocked.
 - User-facing workflow changes have real E2E acceptance evidence; mocked UI/API tests are supplemental only unless the maintainer explicitly accepted the documented gap.
+- User-originated or unclear issues that need reporter confirmation or manual interaction have a documented confirmation path before the PR uses closing keywords.
 - Pre-commit hooks have been run with `prek run --all-files` when hook config exists, or their absence is documented.
 - User-visible changes have a `CHANGELOG.md` entry under `Unreleased`.
 - ABS-facing changes update `test/abs/test-matrix.md` when relevant.
@@ -23,10 +25,12 @@ Include:
 - Summary.
 - Tests run, with exact commands.
 - Real E2E evidence for user-facing workflow changes, or the maintainer-accepted reason it is blocked.
+- Issue origin and reporter-confirmation status when the issue is user-originated or unclear.
 - Docs/changelog status.
 - Follow-up issues or known gaps, if any.
 
 Prefer concise reviewer-oriented text. Do not hide unrun tests.
+Use closing keywords for maintainer-created issues when the PR fully resolves them. For user-originated or unclear issues that need reporter confirmation or manual interaction, use a non-closing issue reference until confirmation or explicit maintainer approval is documented.
 
 ## PR Commands
 
@@ -44,7 +48,8 @@ Prefer enabling auto-merge once checks are green. If GitHub reports `REVIEW_REQU
 
 - Issues normally close through PR merge back into `master`.
 - A branch is not done when implementation is committed, pushed, or opened as a PR. Closeout means the PR is ready, required checks pass, auto-merge is enabled or the PR merges, the linked issue closes, and stale branches or worktrees are cleaned up.
-- Use closing keywords in the PR body when the PR fully resolves the issue.
+- Use closing keywords in the PR body when the PR fully resolves a maintainer-created issue.
+- For user-originated or unclear issues, preserve reporter validation when needed: do not auto-close through PR keywords until reporter confirmation, maintainer approval to close without it, or documented obsolescence/duplication exists.
 - Directly close an issue only when the user explicitly asks, the issue is obsolete/duplicate, or the work intentionally completed outside PR merge.
 - Before closeout, verify acceptance criteria against code, tests, docs, changelog, and PR state.
 - Do not close a user-facing workflow issue based only on mocked/stubbed tests. Confirm real E2E evidence or documented maintainer acceptance of the gap.


### PR DESCRIPTION
Resolves #117

## Summary
- Add shared issue-origin guidance distinguishing maintainer-created, user-originated, and unclear issues.
- Update issue watcher, verification, closeout, and PR guidance so reporter confirmation or manual validation blocks automatic closure when needed.
- Preserve automatic PR closure for maintainer-created issues when acceptance and checks are satisfied.

## Tests
- prek run --all-files
- git diff --check

## Docs / Changelog
- Updated repo-local skills and shared workflow references.
- Added CHANGELOG.md Unreleased note.

## Follow-up
- None.