### PR TITLE
docs: require GoDoc for exported functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,7 @@ ABS feature validation:
 - For bug fixes, prefer first creating or identifying a failing check that demonstrates the problem, then make that check pass.
 - For refactors, verify behavior before and after when practical.
 - Match existing project style even when you would design it differently.
+- Add GoDoc comments for all exported Go functions.
 - Do not clean up unrelated dead code, comments, formatting, or adjacent abstractions. Mention unrelated issues instead.
 - Expect a dirty worktree. Do not revert unrelated changes.
 - Verify with the narrowest relevant repo-native command first, then widen if needed.


### PR DESCRIPTION
## Summary
- Add an AGENTS.md rule requiring GoDoc comments for exported Go functions.

## Tests
- Commit hooks ran during commit.
- Not run: docs-only change.

## Docs/Changelog
- AGENTS.md updated.
- Changelog not updated because this is maintainer guidance only.