### PR TITLE
Add CLI docs capture workflow

### DIFF
--- a/.github/workflows/docs-visuals.yml
+++ b/.github/workflows/docs-visuals.yml
@@ -7,9 +7,11 @@ on:
     paths:
       - ".github/workflows/docs-visuals.yml"
       - "Makefile"
-      - "cmd/web.go"
-      - "cmd/gui.go"
+      - "cmd/**"
+      - "docs/CLI.md"
+      - "docs/visuals/**"
       - "internal/app/**"
+      - "internal/organizer/**"
       - "internal/server/**"
       - "testdata/mp3flat/**"
       - "web/**"
@@ -19,9 +21,11 @@ on:
     paths:
       - ".github/workflows/docs-visuals.yml"
       - "Makefile"
-      - "cmd/web.go"
-      - "cmd/gui.go"
+      - "cmd/**"
+      - "docs/CLI.md"
+      - "docs/visuals/**"
       - "internal/app/**"
+      - "internal/organizer/**"
       - "internal/server/**"
       - "testdata/mp3flat/**"
       - "web/**"
@@ -50,6 +54,11 @@ jobs:
           node-version: '24'
           cache: npm
           cache-dependency-path: web/package-lock.json
+
+      - name: Install VHS
+        uses: charmbracelet/vhs-action@v2
+        with:
+          version: v0.11.0
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5

--- a/.github/workflows/docs-visuals.yml
+++ b/.github/workflows/docs-visuals.yml
@@ -55,10 +55,20 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
+      - name: Install VHS runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+          curl -fsSL -o /tmp/ttyd https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64
+          sudo install -m 755 /tmp/ttyd /usr/local/bin/ttyd
+          ffmpeg -version
+          ttyd --version
+
       - name: Install VHS
-        uses: charmbracelet/vhs-action@v2
-        with:
-          version: v0.11.0
+        run: |
+          go install github.com/charmbracelet/vhs@v0.11.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          "$(go env GOPATH)/bin/vhs" --version
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Layout template CLI help**: Added `audiobook-organizer layout-template` for an in-terminal field reference, fallback syntax, examples, and path safety rules.
 - **Text-only metadata inspection**: `audiobook-organizer metadata` now prints non-interactive metadata scan results, `metadata --json` writes machine-readable output, and `metadata-tui` keeps the old interactive metadata exploration workflow explicit.
 - **Web UI docs screenshots**: Added a local-only Playwright workflow for generating web UI metadata.json preview, review-plan, and embedded-metadata preview screenshots under ignored `output/docs-visuals/web-ui/`, plus a CI artifact workflow for docs visuals.
+- **CLI docs captures**: Added a local-only docs workflow for generating terminal-style CLI help, dry-run organization, metadata inspection, and rename preview PNG captures, plus VHS animated GIFs for short CLI demos, under ignored `output/docs-visuals/cli/`.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ INTEGRATION_TEST_PKGS = $(shell go list ./... | grep -v '/integration$$')
 ABS_TEST_RUN ?= Test(ABSHarnessSmokeResetContract|MetadataJSONMode|EmbeddedAlreadyIndexed|EmbeddedMetadataImport|FlatMode(Mechanics|Import)|RESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints)|ABSMetadataMode)
 ABS_REST_TEST_RUN ?= TestRESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints)
 
-.PHONY: all build clean dev dev-linux-amd64 web-install web-build web-dev docs-web-screenshots docs-visuals gui-rest-test gui-test gui-test-abs gui-test-headed gui-test-ui abs-dev-seed abs-dev-init abs-dev-configure abs-dev-up abs-dev-down abs-dev-reset abs-dev-reset-all abs-dev-scan abs-dev-reset-scan abs-ci-smoke abs-test-metadata abs-test-rest abs-test-matrix abs-test-e2e abs-dev-capture-baseline abs-dev-restore-baseline abs-dev-wait release test test-unit test-integration coverage coverage-html lint fmt fmt-check vet help scp-dev
+.PHONY: all build clean dev dev-linux-amd64 web-install web-build web-dev docs-cli-captures docs-cli-gifs docs-web-screenshots docs-visuals gui-rest-test gui-test gui-test-abs gui-test-headed gui-test-ui abs-dev-seed abs-dev-init abs-dev-configure abs-dev-up abs-dev-down abs-dev-reset abs-dev-reset-all abs-dev-scan abs-dev-reset-scan abs-ci-smoke abs-test-metadata abs-test-rest abs-test-matrix abs-test-e2e abs-dev-capture-baseline abs-dev-restore-baseline abs-dev-wait release test test-unit test-integration coverage coverage-html lint fmt fmt-check vet help scp-dev
 
 # Default target - show help
 all: help
@@ -32,6 +32,8 @@ help:
 	@printf "    %-26s %s\n" "web-install" "Install web frontend dependencies"
 	@printf "    %-26s %s\n" "web-build" "Build embedded web frontend assets"
 	@printf "    %-26s %s\n" "web-dev" "Run the web frontend dev server"
+	@printf "    %-26s %s\n" "docs-cli-captures" "Generate docs captures for the CLI"
+	@printf "    %-26s %s\n" "docs-cli-gifs" "Generate animated docs GIFs for the CLI"
 	@printf "    %-26s %s\n" "docs-web-screenshots" "Generate docs screenshots for the local web UI"
 	@printf "    %-26s %s\n" "docs-visuals" "Generate all local docs visuals"
 	@printf "    %-26s %s\n" "gui-rest-test" "Run local web UI REST endpoint tests"
@@ -102,12 +104,20 @@ web-build:
 web-dev:
 	cd web && npm run dev
 
+# Generate documentation captures for the command-line interface
+docs-cli-captures: dev
+	cd web && npm run docs:cli
+
+# Generate animated documentation GIFs for the command-line interface
+docs-cli-gifs: dev
+	cd web && npm run docs:cli:gifs
+
 # Generate documentation screenshots for the local web UI
 docs-web-screenshots: web-build
 	cd web && npm run docs:screenshots
 
-# Generate all local documentation visuals. Future CLI/TUI capture targets should be added here.
-docs-visuals: docs-web-screenshots
+# Generate all local documentation visuals. Future TUI capture targets should be added here.
+docs-visuals: docs-web-screenshots docs-cli-captures docs-cli-gifs
 
 # Run local web UI REST endpoint tests
 gui-rest-test:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,6 +45,44 @@ docker pull jeffsui/audiobook-organizer:latest
 
 ---
 
+## Local CLI Captures
+
+Generate local command-line documentation captures from the repository root. The output files are local-only and ignored by git:
+
+```bash
+make docs-cli-captures
+```
+
+The workflow builds the CLI binary, copies committed LibriVox sample media from `testdata/mp3flat/` into generated sample data under `output/docs-cli-sample/`, runs representative non-interactive commands, renders terminal-style static PNG captures with Playwright, and writes them under `output/docs-visuals/cli/`.
+
+Current capture names are `help`, `organize-dry-run`, `metadata-inspect`, and `rename-preview`. Regenerate one or more specific captures with:
+
+```bash
+ABO_DOCS_CLI_CAPTURES=help,metadata-inspect make docs-cli-captures
+```
+
+If Playwright-managed Chromium is not installed, run:
+
+```bash
+cd web && npm run install:browsers
+```
+
+Generate animated CLI GIFs with [VHS](https://github.com/charmbracelet/vhs):
+
+```bash
+make docs-cli-gifs
+```
+
+Current GIF capture names are `organize-run`, `metadata-inspect`, and `rename-preview`. The organize run GIF stages fresh sample files, executes a real non-dry-run organize command, and lists the organized output files. Regenerate one or more specific GIFs with:
+
+```bash
+ABO_DOCS_CLI_GIFS=organize-run,rename-preview make docs-cli-gifs
+```
+
+You can also point the PNG workflow at an existing Chrome or Chrome Headless Shell binary with `ABO_DOCS_BROWSER_EXECUTABLE_PATH=/path/to/chrome make docs-cli-captures`. The aggregate `make docs-visuals` target includes web UI screenshots, static CLI PNG captures, and animated CLI GIF captures, and CI uploads the generated files as docs visual artifacts.
+
+---
+
 ## Basic Usage
 
 ### Organize Audiobooks

--- a/docs/visuals/cli/metadata-inspect.tape
+++ b/docs/visuals/cli/metadata-inspect.tape
@@ -1,0 +1,20 @@
+Output output/docs-visuals/cli/cli-metadata-inspect.gif
+
+Require bin/audiobook-organizer
+
+Set Shell "bash"
+Set FontSize 24
+Set Width 1400
+Set Height 560
+Set Theme "TokyoNight"
+Set Padding 24
+Set Framerate 24
+Set PlaybackSpeed 1.15
+Set TypingSpeed 18ms
+Set WindowBar Colorful
+Set BorderRadius 8
+Env NO_COLOR "1"
+
+Type "bin/audiobook-organizer metadata --dir=output/docs-cli-sample/metadata-json/source"
+Enter
+Sleep 3s

--- a/docs/visuals/cli/organize-run.tape
+++ b/docs/visuals/cli/organize-run.tape
@@ -1,0 +1,28 @@
+Output output/docs-visuals/cli/cli-organize-run.gif
+
+Require bin/audiobook-organizer
+
+Set Shell "bash"
+Set FontSize 24
+Set Width 1400
+Set Height 760
+Set Theme "TokyoNight"
+Set Padding 24
+Set Framerate 24
+Set PlaybackSpeed 1.15
+Set TypingSpeed 18ms
+Set WindowBar Colorful
+Set BorderRadius 8
+Env NO_COLOR "1"
+
+Type "bin/audiobook-organizer --dir=output/docs-cli-sample/metadata-json/source --out=output/docs-cli-sample/metadata-json/organized --layout=author-only"
+Enter
+Sleep 2s
+Ctrl+L
+Sleep 500ms
+Type "cd output/docs-cli-sample/metadata-json/organized"
+Enter
+Sleep 500ms
+Type "find . -type f ! -name '.abook-org.log' | sort"
+Enter
+Sleep 4s

--- a/docs/visuals/cli/rename-preview.tape
+++ b/docs/visuals/cli/rename-preview.tape
@@ -1,0 +1,20 @@
+Output output/docs-visuals/cli/cli-rename-preview.gif
+
+Require bin/audiobook-organizer
+
+Set Shell "bash"
+Set FontSize 24
+Set Width 1400
+Set Height 480
+Set Theme "TokyoNight"
+Set Padding 24
+Set Framerate 24
+Set PlaybackSpeed 1.15
+Set TypingSpeed 18ms
+Set WindowBar Colorful
+Set BorderRadius 8
+Env NO_COLOR "1"
+
+Type "bin/audiobook-organizer rename --dir=output/docs-cli-sample/rename/source --use-embedded-metadata --dry-run"
+Enter
+Sleep 3s

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,8 @@
     "dev": "vite --host 127.0.0.1",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview --host 127.0.0.1",
+    "docs:cli": "node scripts/capture-docs-cli.mjs",
+    "docs:cli:gifs": "node scripts/capture-docs-cli-gifs.mjs",
     "docs:screenshots": "node scripts/capture-docs-screenshots.mjs",
     "install:browsers": "playwright install chromium",
     "test:e2e": "npm run build && playwright test",

--- a/web/scripts/capture-docs-cli-gifs.mjs
+++ b/web/scripts/capture-docs-cli-gifs.mjs
@@ -1,0 +1,130 @@
+import { spawn } from 'node:child_process'
+import { mkdir, rm } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createCLISampleLibrary,
+  removeCLISampleLibrary,
+  selectedNamesFromEnv,
+} from './docs-cli-fixtures.mjs'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(webRoot, '..')
+const captureDir = join(repoRoot, 'output', 'docs-visuals', 'cli')
+const sampleRoot = join(repoRoot, 'output', 'docs-cli-sample')
+const tapeDir = join(repoRoot, 'docs', 'visuals', 'cli')
+
+const gifCaptures = [
+  {
+    name: 'organize-run',
+    filename: 'cli-organize-run.gif',
+    tape: 'organize-run.tape',
+  },
+  {
+    name: 'metadata-inspect',
+    filename: 'cli-metadata-inspect.gif',
+    tape: 'metadata-inspect.tape',
+  },
+  {
+    name: 'rename-preview',
+    filename: 'cli-rename-preview.gif',
+    tape: 'rename-preview.tape',
+  },
+]
+const obsoleteGifFiles = ['cli-organize-dry-run.gif']
+
+async function main() {
+  await assertVHS()
+  await mkdir(captureDir, { recursive: true })
+  if (!process.env.ABO_DOCS_CLI_GIFS) {
+    await removeObsoleteGIFs()
+  }
+
+  const generated = []
+  for (const capture of gifsToRun()) {
+    await rm(join(captureDir, capture.filename), { force: true })
+    await createCLISampleLibrary(repoRoot, sampleRoot)
+    try {
+      await runVHS(capture)
+      generated.push(`  output/docs-visuals/cli/${capture.filename}`)
+    } finally {
+      await removeCLISampleLibrary(sampleRoot)
+    }
+  }
+
+  console.log('Wrote local CLI docs GIFs:')
+  for (const path of generated) {
+    console.log(path)
+  }
+}
+
+async function removeObsoleteGIFs() {
+  for (const filename of obsoleteGifFiles) {
+    await rm(join(captureDir, filename), { force: true })
+  }
+}
+
+function gifsToRun() {
+  const selectedGifNames = selectedNamesFromEnv(
+    'ABO_DOCS_CLI_GIFS',
+    gifCaptures.map((capture) => capture.name),
+  )
+  return gifCaptures.filter((capture) => selectedGifNames.has(capture.name))
+}
+
+async function assertVHS() {
+  try {
+    await runCommand('vhs', ['--version'])
+  } catch (error) {
+    throw new Error(
+      `Unable to run VHS for animated CLI GIF captures. Install Charmbracelet VHS, then rerun "make docs-cli-gifs".\n${error}`,
+    )
+  }
+}
+
+async function runVHS(capture) {
+  await runCommand('vhs', ['-q', join(tapeDir, capture.tape)], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+    },
+  })
+}
+
+async function runCommand(command, args, options = {}) {
+  const child = spawn(command, args, {
+    cwd: options.cwd || repoRoot,
+    env: options.env || process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let output = ''
+  child.stdout.on('data', (chunk) => {
+    output += chunk.toString()
+  })
+  child.stderr.on('data', (chunk) => {
+    output += chunk.toString()
+  })
+
+  const exitCode = await new Promise((resolveExit, rejectExit) => {
+    child.once('error', rejectExit)
+    child.once('exit', (code) => {
+      resolveExit(code ?? 1)
+    })
+  })
+
+  if (exitCode !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${exitCode}.\n${output}`)
+  }
+
+  return output
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error(error)
+  process.exitCode = 1
+}

--- a/web/scripts/capture-docs-cli.mjs
+++ b/web/scripts/capture-docs-cli.mjs
@@ -1,0 +1,317 @@
+import { spawn } from 'node:child_process'
+import { mkdir, rm, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright'
+import {
+  createCLISampleLibrary,
+  removeCLISampleLibrary,
+  selectedNamesFromEnv,
+} from './docs-cli-fixtures.mjs'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(webRoot, '..')
+const captureDir = join(repoRoot, 'output', 'docs-visuals', 'cli')
+const sampleRoot = join(repoRoot, 'output', 'docs-cli-sample')
+const cliPath = resolve(repoRoot, process.env.ABO_DOCS_CLI_BINARY || 'bin/audiobook-organizer')
+
+const captures = [
+  {
+    name: 'help',
+    filename: 'cli-help.png',
+    title: 'Command Overview',
+    command: ['--help'],
+  },
+  {
+    name: 'organize-dry-run',
+    filename: 'cli-organize-dry-run.png',
+    title: 'Dry-Run Organization Preview',
+    command: [
+      '--dir=output/docs-cli-sample/metadata-json/source',
+      '--out=output/docs-cli-sample/metadata-json/organized',
+      '--dry-run',
+      '--verbose',
+    ],
+  },
+  {
+    name: 'metadata-inspect',
+    filename: 'cli-metadata-inspect.png',
+    title: 'Metadata Inspection',
+    command: ['metadata', '--dir=output/docs-cli-sample/metadata-json/source'],
+  },
+  {
+    name: 'rename-preview',
+    filename: 'cli-rename-preview.png',
+    title: 'Rename Preview',
+    command: [
+      'rename',
+      '--dir=output/docs-cli-sample/rename/source',
+      '--use-embedded-metadata',
+      '--dry-run',
+    ],
+  },
+]
+
+async function main() {
+  await assertCliBinary()
+  await createCLISampleLibrary(repoRoot, sampleRoot)
+  await rm(captureDir, { recursive: true, force: true })
+  await mkdir(captureDir, { recursive: true })
+
+  let browser
+  try {
+    browser = await launchBrowser()
+    const page = await browser.newPage({
+      viewport: { width: 1500, height: 900 },
+      deviceScaleFactor: 1,
+    })
+
+    const generated = []
+    for (const capture of capturesToRun()) {
+      const result = await runCLI(capture.command)
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `CLI capture "${capture.name}" failed with exit code ${result.exitCode}.\n${result.output}`,
+        )
+      }
+
+      const path = join(captureDir, capture.filename)
+      await renderCapture(page, capture, result.output, path)
+      generated.push(`  output/docs-visuals/cli/${capture.filename}`)
+    }
+
+    console.log('Wrote local CLI docs captures:')
+    for (const path of generated) {
+      console.log(path)
+    }
+  } finally {
+    await browser?.close()
+    await removeCLISampleLibrary(sampleRoot)
+  }
+}
+
+function capturesToRun() {
+  const selectedCaptureNames = selectedNamesFromEnv(
+    'ABO_DOCS_CLI_CAPTURES',
+    captures.map((capture) => capture.name),
+  )
+  return captures.filter((capture) => selectedCaptureNames.has(capture.name))
+}
+
+async function assertCliBinary() {
+  try {
+    const info = await stat(cliPath)
+    if (!info.isFile()) {
+      throw new Error(`${cliPath} is not a file`)
+    }
+  } catch (error) {
+    throw new Error(
+      `Unable to find the CLI binary at ${cliPath}. Run "make docs-cli-captures" from the repository root, or set ABO_DOCS_CLI_BINARY to an existing audiobook-organizer binary.\n${error}`,
+    )
+  }
+}
+
+async function runCLI(args) {
+  const child = spawn(cliPath, args, {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      TERM: 'xterm-256color',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let stdout = ''
+  let stderr = ''
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const exitCode = await new Promise((resolveExit, rejectExit) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      rejectExit(new Error(`Timed out running CLI command: ${formatCommand(args)}`))
+    }, 30_000)
+
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      rejectExit(error)
+    })
+    child.once('exit', (code) => {
+      clearTimeout(timeout)
+      resolveExit(code ?? 1)
+    })
+  })
+
+  return {
+    exitCode,
+    output: normalizeCLIOutput(`${stdout}${stderr}`),
+  }
+}
+
+function normalizeCLIOutput(output) {
+  return output
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')
+    .replaceAll('\r\n', '\n')
+    .replaceAll(`${repoRoot}/`, '')
+    .replaceAll(repoRoot, '.')
+    .replace(/(Duration:\s+).*/g, '$1<1s')
+    .split('\n')
+    .map((line) => line.replace(/\s+$/u, ''))
+    .join('\n')
+    .trimEnd()
+}
+
+async function renderCapture(page, capture, output, path) {
+  await page.setContent(renderHTML(capture, output), { waitUntil: 'load' })
+  const terminal = page.locator('.terminal')
+  await terminal.screenshot({ path })
+}
+
+function renderHTML(capture, output) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family:
+        ui-monospace,
+        SFMono-Regular,
+        Menlo,
+        Monaco,
+        Consolas,
+        "Liberation Mono",
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        monospace;
+      background: #f6f7f9;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 32px;
+      background: #f6f7f9;
+    }
+
+    .terminal {
+      width: 1400px;
+      overflow: hidden;
+      border: 1px solid #273043;
+      border-radius: 8px;
+      background: #111827;
+      box-shadow: 0 18px 48px rgb(15 23 42 / 24%);
+    }
+
+    .chrome {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 44px;
+      padding: 0 18px;
+      color: #cbd5e1;
+      background: #1f2937;
+      border-bottom: 1px solid #334155;
+      font: 600 14px/1.2 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+
+    .dots {
+      display: flex;
+      gap: 8px;
+    }
+
+    .dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+    }
+
+    .red { background: #ef4444; }
+    .yellow { background: #f59e0b; }
+    .green { background: #22c55e; }
+
+    pre {
+      margin: 0;
+      padding: 24px 28px 28px;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      color: #e5e7eb;
+      background: #111827;
+      font-size: 17px;
+      line-height: 1.48;
+      letter-spacing: 0;
+    }
+
+    .prompt {
+      color: #67e8f9;
+    }
+  </style>
+</head>
+<body>
+  <section class="terminal" aria-label="${escapeHTML(capture.title)}">
+    <div class="chrome">
+      <div class="dots" aria-hidden="true">
+        <span class="dot red"></span>
+        <span class="dot yellow"></span>
+        <span class="dot green"></span>
+      </div>
+      <span>${escapeHTML(capture.title)}</span>
+      <span>docs capture</span>
+    </div>
+    <pre><span class="prompt">$</span> ${escapeHTML(formatCommand(capture.command))}
+
+${escapeHTML(output)}</pre>
+  </section>
+</body>
+</html>`
+}
+
+function formatCommand(args) {
+  return ['audiobook-organizer', ...args.map(shellEscape)].join(' ')
+}
+
+function shellEscape(value) {
+  if (/^[A-Za-z0-9_./:=@-]+$/.test(value)) {
+    return value
+  }
+  return `"${value.replaceAll('"', '\\"')}"`
+}
+
+function escapeHTML(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+async function launchBrowser() {
+  try {
+    return await chromium.launch({
+      executablePath: process.env.ABO_DOCS_BROWSER_EXECUTABLE_PATH || process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
+    })
+  } catch (error) {
+    throw new Error(
+      `Unable to launch Chromium for CLI docs captures. Run "cd web && npm run install:browsers" or set ABO_DOCS_BROWSER_EXECUTABLE_PATH to a local Chrome/Chrome Headless Shell binary.\n${error}`,
+    )
+  }
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error(error)
+  process.exitCode = 1
+}

--- a/web/scripts/docs-cli-fixtures.mjs
+++ b/web/scripts/docs-cli-fixtures.mjs
@@ -1,0 +1,66 @@
+import { copyFile, mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const cliCaptureNames = [
+  'help',
+  'organize-dry-run',
+  'metadata-inspect',
+  'rename-preview',
+]
+
+export function selectedNamesFromEnv(envName, validNames = cliCaptureNames) {
+  const selectedNames = new Set(
+    (process.env[envName] || '')
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean),
+  )
+
+  if (selectedNames.size === 0) {
+    return new Set(validNames)
+  }
+
+  const knownNames = new Set(validNames)
+  const unknownNames = [...selectedNames].filter((name) => !knownNames.has(name))
+  if (unknownNames.length > 0) {
+    throw new Error(
+      `Unknown CLI capture name(s): ${unknownNames.join(', ')}. Valid names: ${validNames.join(', ')}`,
+    )
+  }
+
+  return selectedNames
+}
+
+export async function createCLISampleLibrary(repoRoot, sampleRoot) {
+  await rm(sampleRoot, { recursive: true, force: true })
+  await mkdir(join(sampleRoot, 'metadata-json', 'organized'), { recursive: true })
+  await mkdir(join(sampleRoot, 'rename', 'source'), { recursive: true })
+
+  await createMetadataBook(repoRoot, sampleRoot, {
+    sourceFile: 'testdata/mp3flat/charlesdexterward_01_lovecraft_64kb.mp3',
+    targetFile: '01-chapter-1.mp3',
+    metadata: {
+      title: 'The Case of Charles Dexter Ward',
+      authors: ['H. P. Lovecraft'],
+      series: ['LibriVox Horror Classics #1'],
+      narrators: ['LibriVox Volunteers'],
+      publishedYear: '1927',
+    },
+  })
+
+  await copyFile(
+    join(repoRoot, 'testdata/mp3flat/falstaffswedding1766version_1_kenrick_64kb.mp3'),
+    join(sampleRoot, 'rename', 'source', 'falstaffswedding1766version_1_kenrick_64kb.mp3'),
+  )
+}
+
+export async function removeCLISampleLibrary(sampleRoot) {
+  await rm(sampleRoot, { recursive: true, force: true })
+}
+
+async function createMetadataBook(repoRoot, sampleRoot, { sourceFile, targetFile, metadata }) {
+  const bookDir = join(sampleRoot, 'metadata-json', 'source')
+  await mkdir(bookDir, { recursive: true })
+  await writeFile(join(bookDir, 'metadata.json'), JSON.stringify(metadata, null, 2))
+  await copyFile(join(repoRoot, sourceFile), join(bookDir, targetFile))
+}


### PR DESCRIPTION
Resolves #145

## Summary

- add static Playwright-rendered CLI PNG captures for help, dry-run organize, metadata inspection, and rename preview
- add VHS animated CLI GIF captures for a full-cycle organize run, metadata inspection, and rename preview
- wire CLI captures into `make docs-visuals`, CI artifact generation, docs, and changelog

## Tests

- `node --check web/scripts/capture-docs-cli.mjs`
- `node --check web/scripts/capture-docs-cli-gifs.mjs`
- `node --check web/scripts/docs-cli-fixtures.mjs`
- `vhs validate docs/visuals/cli/*.tape`
- `make docs-cli-captures`
- `make docs-cli-gifs`
- `make docs-visuals`
- `ABO_DOCS_CLI_GIFS=organize-run npm run docs:cli:gifs`
- `prek run --all-files`
- `git diff --check`

## Docs and Changelog

- Updated `docs/CLI.md` with PNG/GIF regeneration commands and filters.
- Updated `CHANGELOG.md` under Unreleased.
- ABS matrix update is not applicable; this only changes documentation visual generation.
