### PR TITLE
docs: publish generated documentation site

### DIFF
--- a/.github/workflows/docs-visuals.yml
+++ b/.github/workflows/docs-visuals.yml
@@ -1,5 +1,10 @@
 name: Docs Visuals
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 on:
   workflow_dispatch:
   pull_request:
@@ -8,8 +13,8 @@ on:
       - ".github/workflows/docs-visuals.yml"
       - "Makefile"
       - "cmd/**"
-      - "docs/CLI.md"
-      - "docs/TUI.md"
+      - "README.md"
+      - "docs/**"
       - "docs/visuals/**"
       - "internal/app/**"
       - "internal/organizer/**"
@@ -17,15 +22,14 @@ on:
       - "internal/tui/**"
       - "testdata/mp3flat/**"
       - "web/**"
-      - "docs/GUI.md"
   push:
     branches: [ "master" ]
     paths:
       - ".github/workflows/docs-visuals.yml"
       - "Makefile"
       - "cmd/**"
-      - "docs/CLI.md"
-      - "docs/TUI.md"
+      - "README.md"
+      - "docs/**"
       - "docs/visuals/**"
       - "internal/app/**"
       - "internal/organizer/**"
@@ -33,7 +37,10 @@ on:
       - "internal/tui/**"
       - "testdata/mp3flat/**"
       - "web/**"
-      - "docs/GUI.md"
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
 
 jobs:
   docs-visuals:
@@ -93,8 +100,17 @@ jobs:
       - name: Generate docs visuals
         run: make docs-visuals
 
+      - name: Build docs site
+        run: make docs-site
+
+      - name: Verify docs site
+        run: make docs-verify
+
       - name: List generated visuals
         run: find output/docs-visuals -maxdepth 3 -type f -print
+
+      - name: List generated docs site
+        run: find output/docs-site -maxdepth 4 -type f -print
 
       - name: Upload docs visuals
         uses: actions/upload-artifact@v7
@@ -103,3 +119,25 @@ jobs:
           path: output/docs-visuals/**
           if-no-files-found: error
           retention-days: 14
+
+      - name: Upload docs site artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-site
+          path: output/docs-site/**
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: output/docs-site
+
+      - name: Deploy GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/deploy-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Web UI docs screenshots**: Added a local-only Playwright workflow for generating web UI metadata.json preview, review-plan, and embedded-metadata preview screenshots under ignored `output/docs-visuals/web-ui/`, plus a CI artifact workflow for docs visuals.
 - **CLI docs captures**: Added a local-only docs workflow for generating terminal-style CLI help, dry-run organization, metadata inspection, and rename preview PNG captures, plus VHS animated GIFs for short CLI demos, under ignored `output/docs-visuals/cli/`.
 - **TUI docs captures**: Added a VHS workflow for generating animated organize and rename TUI captures plus static final-frame PNGs under ignored `output/docs-visuals/tui/`.
+- **Docs site publishing**: Added a lightweight generated documentation site, GitHub Pages publishing path for generated visuals, docs link verification, and a concise README landing page.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ INTEGRATION_TEST_PKGS = $(shell go list ./... | grep -v '/integration$$')
 ABS_TEST_RUN ?= Test(ABSHarnessSmokeResetContract|MetadataJSONMode|EmbeddedAlreadyIndexed|EmbeddedMetadataImport|FlatMode(Mechanics|Import)|RESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints)|ABSMetadataMode)
 ABS_REST_TEST_RUN ?= TestRESTHarness_((MetadataJSONMode|EmbeddedMetadataImport|FlatModeImport)Lifecycle|ABS(Setup|Operation)Endpoints)
 
-.PHONY: all build clean dev dev-linux-amd64 web-install web-build web-dev docs-cli-captures docs-cli-gifs docs-tui-image docs-tui-captures docs-web-screenshots docs-visuals gui-rest-test gui-test gui-test-abs gui-test-headed gui-test-ui abs-dev-seed abs-dev-init abs-dev-configure abs-dev-up abs-dev-down abs-dev-reset abs-dev-reset-all abs-dev-scan abs-dev-reset-scan abs-ci-smoke abs-test-metadata abs-test-rest abs-test-matrix abs-test-e2e abs-dev-capture-baseline abs-dev-restore-baseline abs-dev-wait release test test-unit test-integration coverage coverage-html lint fmt fmt-check vet help scp-dev
+.PHONY: all build clean dev dev-linux-amd64 web-install web-build web-dev docs-cli-captures docs-cli-gifs docs-tui-image docs-tui-captures docs-web-screenshots docs-visuals docs-site docs-publish-site docs-verify gui-rest-test gui-test gui-test-abs gui-test-headed gui-test-ui abs-dev-seed abs-dev-init abs-dev-configure abs-dev-up abs-dev-down abs-dev-reset abs-dev-reset-all abs-dev-scan abs-dev-reset-scan abs-ci-smoke abs-test-metadata abs-test-rest abs-test-matrix abs-test-e2e abs-dev-capture-baseline abs-dev-restore-baseline abs-dev-wait release test test-unit test-integration coverage coverage-html lint fmt fmt-check vet help scp-dev
 
 # Default target - show help
 all: help
@@ -41,6 +41,9 @@ help:
 	@printf "    %-26s %s\n" "docs-tui-captures" "Generate docs captures for the TUI"
 	@printf "    %-26s %s\n" "docs-web-screenshots" "Generate docs screenshots for the local web UI"
 	@printf "    %-26s %s\n" "docs-visuals" "Generate all local docs visuals"
+	@printf "    %-26s %s\n" "docs-site" "Build the static documentation site"
+	@printf "    %-26s %s\n" "docs-publish-site" "Generate visuals and build the publishable docs site"
+	@printf "    %-26s %s\n" "docs-verify" "Verify docs links and generated site assets"
 	@printf "    %-26s %s\n" "gui-rest-test" "Run local web UI REST endpoint tests"
 	@printf "    %-26s %s\n" "gui-test" "Run local web UI Playwright tests"
 	@printf "    %-26s %s\n" "gui-test-abs" "Run Docker-backed ABS web UI Playwright test"
@@ -137,6 +140,17 @@ docs-web-screenshots: web-build
 
 # Generate all local documentation visuals.
 docs-visuals: docs-web-screenshots docs-cli-captures docs-cli-gifs docs-tui-captures
+
+# Build the static documentation site from Markdown.
+docs-site:
+	cd web && npm run docs:site
+
+# Generate visuals and build the site artifact that GitHub Pages publishes.
+docs-publish-site: docs-visuals docs-site docs-verify
+
+# Verify documentation links and required published assets.
+docs-verify: docs-site
+	cd web && npm run docs:verify
 
 # Run local web UI REST endpoint tests
 gui-rest-test:

--- a/README.md
+++ b/README.md
@@ -1,65 +1,34 @@
-# Audiobook Organizer
+# Audiobook Organizer for Audiobookshelf (and More)
 
-Audiobook Organizer is a Go-based audiobook library organizer and renamer for Audiobookshelf users and local audiobook collections.
-It cleans up audiobook folders, previews file moves before they happen, renames files from metadata templates, and reads metadata from `metadata.json`, EPUB, MP3 ID3 tags, M4B files, and Audiobookshelf.
+Audiobook Organizer is a single Go binary for previewing, organizing, renaming, and inspecting audiobook libraries. It works with local folders, Audiobookshelf libraries, `metadata.json`, embedded EPUB/MP3/M4B metadata, and metadata field mappings.
 
 [![codecov](https://codecov.io/gh/jeeftor/audiobook-organizer/branch/master/graph/badge.svg)](https://codecov.io/gh/jeeftor/audiobook-organizer)
 [![Coverage Status](https://coveralls.io/repos/github/jeeftor/audiobook-organizer/badge.svg?branch=master)](https://coveralls.io/github/jeeftor/audiobook-organizer?branch=master)
 
-![Audiobook Organizer logo](docs/logo.png)
+![Audiobook Organizer web UI preview](https://jeeftor.github.io/audiobook-organizer/assets/generated/web-ui/web-ui-metadata-json-preview.png)
 
-Use Audiobook Organizer when you want to:
+![Animated CLI organize run](https://jeeftor.github.io/audiobook-organizer/assets/generated/cli/cli-organize-run.gif)
 
-- turn messy audiobook folders into predictable layouts such as `Author/Series/Title`;
-- preview moves, copies, and renames with dry-run output before changing files;
-- standardize audiobook filenames from title, author, series, track, and disc metadata;
-- inspect or map metadata from `metadata.json`, embedded EPUB/MP3/M4B tags, and Audiobookshelf;
-- trigger Audiobookshelf scans after filesystem changes so the server can reconcile moved items.
+![Animated TUI organize preview](https://jeeftor.github.io/audiobook-organizer/assets/generated/tui/tui-organize-preview.gif)
 
-The project now ships one `audiobook-organizer` binary with:
+Use it when you want to:
 
-- a local browser UI: `audiobook-organizer web`
-- terminal workflows: `audiobook-organizer tui`, `rename-tui`, and `metadata-tui`
-- scriptable CLI workflows: root organize command, `rename`, `metadata`, and `abs`
+- preview filesystem changes before moving or renaming audiobook files;
+- organize messy folders into predictable layouts such as `Author/Series/Title`;
+- rename files from metadata templates;
+- inspect and map metadata from sidecar JSON, embedded tags, and Audiobookshelf;
+- trigger Audiobookshelf scans after filesystem changes;
+- undo organization and rename operations from generated logs.
 
-`audiobook-organizer gui` remains as a compatibility alias for `audiobook-organizer web`.
+## Audiobookshelf `metadata.json` Setup
 
-Common audiobook workflows:
+If Audiobookshelf is your metadata source, enable **Store metadata with item** in the Audiobookshelf library settings before organizing. Audiobookshelf will write a `metadata.json` sidecar into each book directory when metadata is generated or updated, and Audiobook Organizer can use those sidecars as the default metadata source.
 
-- [Organize audiobook libraries](docs/CLI.md) into layouts such as `Author/Series/Title`.
-- [Rename audiobook files](docs/RENAME_FEATURE.md) with metadata templates and dry-run previews.
-- [Use Audiobookshelf metadata and scan workflows](#audiobookshelf-workflows).
-- [Read metadata from metadata.json, EPUB, MP3, and M4B files](docs/METADATA.md).
-- [Install with Homebrew, Go, Docker, or release packages](docs/INSTALLATION.md).
+![Audiobookshelf setting for storing metadata.json files](docs/store_metadata.jpg)
 
-## Audiobook Library Workflows
+After a real organization run, Audiobookshelf may briefly show old paths as missing until the library scans and reconciles the moved files. See [Audiobookshelf](docs/audiobookshelf.md) for the setup, cleanup screenshots, path mapping checks, and scan workflow.
 
-- **Organize audiobook folders** into predictable directory layouts such as `Author/Series/Title`.
-- **Rename audiobook files** with templates such as `{author} - {series} {series_number} - {title}`.
-- **Preview filesystem changes** with dry-run output before moving, copying, or renaming files.
-- **Read audiobook metadata** from `metadata.json`, EPUB, MP3, M4B, and Audiobookshelf sources.
-- **Map non-standard metadata fields** so custom tags can still provide author, title, series, track, and disc values.
-- **Recover from changes** with organization and rename logs that support undo.
-- **Work from your preferred interface** with local browser, terminal, and command-line workflows.
-- **Coordinate with Audiobookshelf** through library discovery, path mapping checks, item previews, scan triggers, and WebSocket scan event testing.
-
-## Current Interfaces
-
-| Interface | Command | Best For | Status |
-| --- | --- | --- | --- |
-| Local web UI | `audiobook-organizer web` | Browser-based preview, configuration, rename preview, ABS connection workflows | Current GUI direction |
-| GUI alias | `audiobook-organizer gui` | Existing muscle memory/scripts | Alias for `web` |
-| Organize CLI | `audiobook-organizer --dir=/books` | Batch organization and automation | Stable |
-| Organization TUI | `audiobook-organizer tui` | Keyboard-first interactive organization | Stable |
-| Rename CLI | `audiobook-organizer rename --dir=/books` | Scriptable file renaming | Stable |
-| Rename TUI | `audiobook-organizer rename-tui --dir=/books` | Interactive rename previews | Stable |
-| Metadata CLI | `audiobook-organizer metadata --dir=/books` | Text-only metadata inspection | Stable |
-| Metadata TUI | `audiobook-organizer metadata-tui --dir=/books` | Metadata inspection and template exploration | Stable |
-| Audiobookshelf CLI | `audiobook-organizer abs ...` | ABS discovery, path mapping, metadata previews, ABS metadata organization, and scan triggers | Active development |
-
-## Quick Start
-
-### Install
+## Install
 
 Homebrew:
 
@@ -80,346 +49,126 @@ Docker:
 docker pull jeffsui/audiobook-organizer:latest
 ```
 
-Release archives and Linux packages are available from [GitHub Releases](https://github.com/jeeftor/audiobook-organizer/releases).
+Release archives and Linux packages are available from [GitHub Releases](https://github.com/jeeftor/audiobook-organizer/releases). See the [installation guide](docs/INSTALLATION.md) for package details and platform notes.
 
-See [docs/INSTALLATION.md](docs/INSTALLATION.md) for platform-specific installation notes.
+## Safe First Run
 
-### Start The Browser UI
+Start with a dry run against a small source folder and a separate output directory:
+
+```bash
+audiobook-organizer \
+  --dir=/path/to/books \
+  --out=/path/to/organized \
+  --dry-run \
+  --verbose
+```
+
+Review the planned paths and warnings. Run for real only after the preview looks right:
+
+```bash
+audiobook-organizer \
+  --dir=/path/to/books \
+  --out=/path/to/organized
+```
+
+Organization writes `.abook-org.log`; rename writes `.abook-rename.log`. Keep those logs until you are satisfied with the result. See [Getting Started](docs/getting-started.md) and [Safety And Undo](docs/safety-and-undo.md).
+
+## Choose A Workflow
+
+| Interface | Command | Best For |
+| --- | --- | --- |
+| Local web UI | `audiobook-organizer web` | Browser setup, visual previews, rename review, Audiobookshelf connection checks |
+| Organize | `audiobook-organizer --dir=/books` | Main workflow for repeatable scripts and batch organization |
+| Organization TUI | `audiobook-organizer tui` | Keyboard-first interactive organization |
+| Rename Files | `audiobook-organizer rename --dir=/books` | Scriptable filename cleanup |
+| Rename TUI | `audiobook-organizer rename-tui --dir=/books` | Interactive rename previews and field mapping |
+| Explore Metadata | `audiobook-organizer metadata --dir=/books` | Text or JSON metadata inspection |
+| Audiobookshelf CLI | `audiobook-organizer abs ...` | ABS library discovery, path mapping, organization, and scan workflows |
+
+Full comparison: [Choose An Interface](docs/interfaces.md).
+
+## Common Commands
+
+Start the local browser UI:
 
 ```bash
 audiobook-organizer web
 ```
 
-The web UI starts a local HTTP server, binds to `127.0.0.1` by default, generates a temporary session token, and opens your browser.
-
-Useful variants:
+Preview an organization run:
 
 ```bash
-# Pre-fill source and output directories
-audiobook-organizer web --input=/path/to/books --output=/path/to/organized
-
-# Choose a local port
-audiobook-organizer web --host=127.0.0.1 --port=8080
-
-# Print the URL without opening a browser
-audiobook-organizer web --no-open
-
-# Compatibility alias
-audiobook-organizer gui
+audiobook-organizer --dir=/books/source --out=/books/organized --dry-run
 ```
 
-The current web API supports preview-oriented organization and rename flows plus Audiobookshelf library, path mapping, item loading, and scan-trigger endpoints. Use the CLI or TUI for full filesystem execution when needed.
-
-See [docs/GUI.md](docs/GUI.md) for the local web UI guide.
-
-### Preview And Organize From The CLI
+Rename files with a template:
 
 ```bash
-# Preview without moving files
-audiobook-organizer --dir=/path/to/books --out=/path/to/organized --dry-run
-
-# Organize to a separate output directory
-audiobook-organizer --dir=/path/to/books --out=/path/to/organized
-
-# Organize in place
-audiobook-organizer --dir=/path/to/books
-
-# Undo the previous organization operation
-audiobook-organizer --dir=/path/to/books --undo
-```
-
-Common organization flags:
-
-| Flag | Purpose |
-| --- | --- |
-| `--dir`, `--input` | Source directory |
-| `--out`, `--output` | Output directory; defaults to source |
-| `--dry-run` | Preview without changing files |
-| `--layout` | Directory layout |
-| `--use-embedded-metadata` | Use embedded EPUB/MP3/M4B metadata |
-| `--flat` | Process files individually; also enables embedded metadata |
-| `--remove-empty` | Remove empty source directories after moving |
-| `--skip-errors` | Continue past missing or invalid metadata |
-| `--layout-template` | Custom directory layout template overriding `--layout`; see `audiobook-organizer layout-template` |
-| `--author-fields`, `--title-field`, `--series-field`, `--track-field`, `--disc-field` | Field mapping overrides |
-
-See [docs/CLI.md](docs/CLI.md) for the full CLI reference.
-
-### Rename Files
-
-```bash
-# Preview renames
-audiobook-organizer rename --dir=/path/to/books --dry-run
-
-# Rename using a template
 audiobook-organizer rename \
-  --dir=/path/to/books \
-  --template="{author} - {series} {series_number} - {title}"
-
-# Rename from embedded metadata
-audiobook-organizer rename --dir=/path/to/books --use-embedded-metadata
-
-# Undo the previous rename operation
-audiobook-organizer rename --dir=/path/to/books --undo
-
-# Open the interactive rename TUI
-audiobook-organizer rename-tui --dir=/path/to/books
-```
-
-Template help:
-
-```bash
-audiobook-organizer layout-template
-audiobook-organizer rename help-template
-```
-
-See [docs/RENAME_FEATURE.md](docs/RENAME_FEATURE.md) for rename templates and examples.
-
-### Use The TUI
-
-```bash
-# Interactive organization workflow
-audiobook-organizer tui
-
-# Start with paths pre-filled
-audiobook-organizer tui --dir=/path/to/books --out=/path/to/organized
-
-# Interactive rename workflow
-audiobook-organizer rename-tui --dir=/path/to/books
-
-# Text-only metadata inspection
-audiobook-organizer metadata --dir=/path/to/books
-
-# Metadata exploration workflow
-audiobook-organizer metadata-tui --dir=/path/to/books
-```
-
-See [docs/TUI.md](docs/TUI.md) and [docs/METADATA_COMMAND.md](docs/METADATA_COMMAND.md).
-
-## Audiobookshelf Workflows
-
-Audiobookshelf support is available in both the local web UI and the `abs` CLI command group.
-
-Current ABS command group:
-
-```bash
-# List/discover libraries and item counts
-audiobook-organizer abs scan \
-  --abs-url=http://localhost:13378 \
-  --abs-token="$ABS_TOKEN"
-
-# Preview ABS metadata with manual container-to-host path mapping
-audiobook-organizer abs scan \
-  --abs-url=http://localhost:13378 \
-  --abs-token="$ABS_TOKEN" \
-  --abs-library=Audiobooks \
-  --abs-path-map="/audiobooks:/mnt/media/audiobooks" \
-  --dir=/mnt/media/audiobooks \
-  --check-files
-
-# Organize already-indexed items using ABS metadata as the source of truth
-audiobook-organizer abs organize \
-  --abs-url=http://localhost:13378 \
-  --abs-token="$ABS_TOKEN" \
-  --abs-library=Audiobooks \
-  --abs-path-map="/audiobooks:/mnt/media/audiobooks" \
-  --dir=/mnt/media/audiobooks \
-  --layout=author-title
-
-# Test SQLite-backed path mapping discovery
-audiobook-organizer abs test-paths \
-  --abs-sqlite=/path/to/absdatabase.sqlite \
-  --dir=/mnt/media/audiobooks
-
-# Trigger an ABS library scan after filesystem changes
-audiobook-organizer abs scan-trigger \
-  --abs-url=http://localhost:13378 \
-  --abs-token="$ABS_TOKEN" \
-  --abs-library=Audiobooks
-
-# Listen for scan events over the ABS WebSocket API
-audiobook-organizer abs websocket-test \
-  --abs-url=http://localhost:13378 \
-  --abs-token="$ABS_TOKEN"
-```
-
-`abs organize` uses Audiobookshelf API metadata for already-indexed files and then sends the mapped local paths through the same organizer core used by the normal CLI. Preview with `abs scan` first when setting up path mappings. After non-dry-run moves, trigger an ABS scan so Audiobookshelf can reconcile old missing paths and newly organized paths.
-
-## Metadata Sources
-
-Audiobook Organizer can use:
-
-1. `metadata.json` sidecars, including Audiobookshelf-style metadata.
-2. Embedded EPUB metadata.
-3. Embedded MP3 ID3 tags.
-4. Embedded M4B metadata.
-5. Audiobookshelf API metadata for ABS workflows.
-
-Processing modes:
-
-- Non-flat mode, the default, treats each directory as one book or album.
-- Flat mode processes each supported file independently and automatically enables embedded metadata.
-- Hybrid behavior can combine `metadata.json` book-level data with embedded track-level data when both are present.
-- Field mapping lets you choose which raw metadata fields should be treated as author, title, series, track, and disc.
-
-See [docs/METADATA.md](docs/METADATA.md).
-
-## Directory Layouts
-
-Supported layout values:
-
-| Layout | Example |
-| --- | --- |
-| `author-series-title` | `Author/Series/Title/` |
-| `author-series-title-number` | `Author/Series/#1 - Title/` |
-| `author-series` | `Author/Series/` |
-| `author-title` | `Author/Title/` |
-| `author-only` | `Author/` |
-| `series-title` | `Series/Title/` |
-| `series-title-number` | `Series/#1 - Title/` |
-
-Example:
-
-```bash
-audiobook-organizer \
-  --dir=/path/to/books \
-  --out=/path/to/organized \
-  --layout=author-title \
+  --dir=/books/source \
+  --template="{author} - {series} {series_number} - {title}" \
   --dry-run
 ```
 
-Custom templates can override the fixed layouts:
+Inspect metadata:
 
 ```bash
-audiobook-organizer \
-  --dir=/path/to/books \
-  --out=/path/to/organized \
-  --layout-template="{author}/{series}/{series-count} - {title} ({narrator})"
+audiobook-organizer metadata --dir=/books/source
 ```
 
-Run `audiobook-organizer layout-template` for the in-terminal field reference, or see [docs/LAYOUTS.md](docs/LAYOUTS.md).
-
-## Configuration
-
-Configuration can come from flags, environment variables, or YAML config.
-
-Config lookup:
-
-1. `--config /custom/path.yaml`
-2. `./.audiobook-organizer.yaml`
-3. `~/.audiobook-organizer.yaml`
-
-Example:
-
-```yaml
-dir: "/path/to/audiobooks"
-out: "/path/to/organized"
-layout: "author-series-title"
-layout-template: ""
-use-embedded-metadata: true
-remove-empty: true
-author-fields: "authors,narrators,album_artist,artist"
-title-field: "album"
-```
-
-Environment examples:
+Check Audiobookshelf path mapping:
 
 ```bash
-export AO_DIR="/path/to/audiobooks"
-export AO_OUTPUT="/path/to/organized"
-export AO_LAYOUT="author-series-title"
-export AO_LAYOUT_TEMPLATE="{author}/{series}/{series-count} - {title}"
-export AO_USE_EMBEDDED_METADATA=true
+audiobook-organizer abs scan \
+  --abs-url=http://localhost:13378 \
+  --abs-token="$ABS_TOKEN" \
+  --abs-path-map="/audiobooks:/mnt/media/audiobooks" \
+  --dir=/mnt/media/audiobooks \
+  --check-files
 ```
-
-Precedence is: defaults, config file, environment variables, CLI flags.
-
-See [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
-
-## Docker
-
-```bash
-# Read/write organization inside one mounted library
-docker run --rm \
-  -v /media/audiobooks:/books \
-  jeffsui/audiobook-organizer --dir=/books --dry-run
-
-# Separate read-only input and writable output
-docker run --rm \
-  -v /media/source:/input:ro \
-  -v /media/organized:/output \
-  jeffsui/audiobook-organizer --dir=/input --out=/output
-
-# Configure with environment variables
-docker run --rm \
-  -v /media/audiobooks:/books \
-  -e AO_LAYOUT=author-series-title \
-  -e AO_VERBOSE=true \
-  jeffsui/audiobook-organizer --dir=/books
-```
-
-See [docs/CLI.md#docker-usage](docs/CLI.md).
-
-## Development
-
-```bash
-git clone https://github.com/jeeftor/audiobook-organizer.git
-cd audiobook-organizer
-
-# Build the Go binary
-make dev
-
-# Install and build embedded web assets
-make web-install
-make web-build
-
-# Run unit tests
-make test-unit
-
-# Run lint checks
-make lint
-```
-
-ABS harness commands:
-
-```bash
-make abs-ci-smoke
-make abs-test-metadata
-make abs-test-e2e
-```
-
-New or changed ABS-facing features should be reflected in [test/abs/test-matrix.md](test/abs/test-matrix.md) and promoted into the ABS test workflow when implemented.
 
 ## Documentation
 
-- [Installation Guide](docs/INSTALLATION.md)
-- [Local Web UI Guide](docs/GUI.md)
-- [TUI Guide](docs/TUI.md)
-- [CLI Reference](docs/CLI.md)
-- [Configuration](docs/CONFIGURATION.md)
-- [Metadata Guide](docs/METADATA.md)
-- [Layout Guide](docs/LAYOUTS.md)
-- [Rename Feature](docs/RENAME_FEATURE.md)
-- [Metadata Command](docs/METADATA_COMMAND.md)
+Published docs: <https://jeeftor.github.io/audiobook-organizer/>
 
-## Updates
+Repo docs:
+
+- [Installation](docs/INSTALLATION.md)
+- [Getting Started](docs/getting-started.md)
+- [Choose An Interface](docs/interfaces.md)
+- [Organize](docs/organize.md)
+- [Rename Files](docs/RENAME_FEATURE.md)
+- [Explore Metadata](docs/explore-metadata.md)
+- [Local Web UI](docs/GUI.md)
+- [CLI](docs/CLI.md)
+- [TUI](docs/TUI.md)
+- [Audiobookshelf](docs/audiobookshelf.md)
+- [Metadata Sources](docs/METADATA.md)
+- [Layouts](docs/LAYOUTS.md)
+- [Configuration](docs/CONFIGURATION.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Changelog](CHANGELOG.md)
+
+## Generated Visuals
+
+Pull requests upload generated screenshots and GIFs as short-lived Actions artifacts for review. `master` publishes the same generated visuals to stable GitHub Pages paths under `assets/generated/`.
+
+Regenerate locally:
 
 ```bash
-# Check for updates
-audiobook-organizer update --check
-
-# Install the latest release when supported by the install method
-audiobook-organizer update
+make docs-publish-site
 ```
 
-## Support
+See [Docs Visuals](docs/development/docs-visuals.md).
 
-- Bug reports: [GitHub Issues](https://github.com/jeeftor/audiobook-organizer/issues)
-- Feature requests and questions: [GitHub Discussions](https://github.com/jeeftor/audiobook-organizer/discussions)
-- Releases: [GitHub Releases](https://github.com/jeeftor/audiobook-organizer/releases)
-- Docker Hub: [jeffsui/audiobook-organizer](https://hub.docker.com/r/jeffsui/audiobook-organizer)
-- Homebrew Tap: [jeeftor/tap](https://github.com/jeeftor/homebrew-tap)
+## Development
 
-## License
+Common checks:
 
-MIT License. See [LICENSE](LICENSE).
+```bash
+make test
+make web-build
+make docs-verify
+```
+
+See [AGENTS.md](AGENTS.md) for repository workflow rules and maintainer guidance.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -28,17 +28,17 @@ You can also download the macOS archive from GitHub Releases and place the `audi
 
 ## Linux
 
-Install the release package for your distribution, or download the archive from GitHub Releases.
+Download the package or archive for your platform from [GitHub Releases](https://github.com/jeeftor/audiobook-organizer/releases). The examples below assume you downloaded a release package file into the current directory. The project does not currently document an APT, Yum/DNF, or APK repository that makes `apt install audiobook-organizer` work without first downloading or configuring a package source.
 
 ```bash
-# Debian/Ubuntu package, if published for the release
-sudo apt install audiobook-organizer
+# Debian/Ubuntu .deb package
+sudo apt install ./audiobook-organizer_*_linux_amd64.deb
 
-# RedHat/Fedora package, if published for the release
-sudo yum install audiobook-organizer
+# RedHat/Fedora .rpm package
+sudo dnf install ./audiobook-organizer-*.x86_64.rpm
 
-# Alpine package, if published for the release
-sudo apk add audiobook-organizer
+# Alpine .apk package
+sudo apk add --allow-untrusted ./audiobook-organizer-*.apk
 
 audiobook-organizer web
 ```

--- a/docs/audiobookshelf.md
+++ b/docs/audiobookshelf.md
@@ -1,0 +1,110 @@
+# Audiobookshelf
+
+Audiobookshelf workflows are for libraries where ABS already knows the book metadata or where ABS needs to rescan after filesystem changes.
+
+## Configure `metadata.json` Sidecars
+
+For the standard local-folder organize workflow, configure Audiobookshelf to store metadata alongside your books. When this ABS setting is enabled, Audiobookshelf writes a `metadata.json` file into each book directory whenever metadata is generated or updated. Audiobook Organizer can then use those sidecar files as the default metadata source.
+
+![Audiobookshelf setting for storing metadata.json files](store_metadata.jpg)
+
+After this is enabled, a book directory can look like this:
+
+```text
+/audiobooks/The Case of Charles Dexter Ward/
+  metadata.json
+  01 - Chapter 1.mp3
+  02 - Chapter 2.mp3
+```
+
+You can preview the organizer against those sidecars without changing files:
+
+```bash
+audiobook-organizer \
+  --dir=/audiobooks \
+  --out=/organized-audiobooks \
+  --dry-run
+```
+
+Use [Explore Metadata](explore-metadata.md) if you want to inspect what the tool reads from `metadata.json` before organizing.
+
+## Common Scenarios
+
+| Scenario | Use |
+| --- | --- |
+| Organize from ABS-created `metadata.json` sidecars | normal `audiobook-organizer --dir=... --dry-run` |
+| Discover libraries and item counts | `audiobook-organizer abs scan` |
+| Validate container-to-host path mapping | `abs scan --abs-path-map=... --check-files` |
+| Preview already-indexed metadata | `abs scan --abs-library=... --dir=...` |
+| Organize files using ABS metadata | `audiobook-organizer abs organize` |
+| Trigger a scan after changes | ABS scan options or the local web UI ABS controls |
+
+## Path Mapping
+
+ABS often runs in a container. The path ABS reports may be different from the host path the organizer can access.
+
+```text
+ABS container path: /audiobooks/The Case of Charles Dexter Ward
+Host path:          /mnt/media/audiobooks/The Case of Charles Dexter Ward
+Mapping flag:       --abs-path-map="/audiobooks:/mnt/media/audiobooks"
+```
+
+Use `--check-files` before organizing so missing or incorrect mappings are visible:
+
+```bash
+audiobook-organizer abs scan \
+  --abs-url=http://localhost:13378 \
+  --abs-token="$ABS_TOKEN" \
+  --abs-library=Audiobooks \
+  --abs-path-map="/audiobooks:/mnt/media/audiobooks" \
+  --dir=/mnt/media/audiobooks \
+  --check-files
+```
+
+## Organize With ABS Metadata
+
+Preview first:
+
+```bash
+audiobook-organizer abs organize \
+  --abs-url=http://localhost:13378 \
+  --abs-token="$ABS_TOKEN" \
+  --abs-library=Audiobooks \
+  --abs-path-map="/audiobooks:/mnt/media/audiobooks" \
+  --dir=/mnt/media/audiobooks \
+  --out=/mnt/media/organized \
+  --dry-run
+```
+
+Then run without `--dry-run` after the plan looks right.
+
+## Web UI ABS Flow
+
+The local web UI can test the ABS URL/token, load libraries, validate path mapping, load item metadata, and trigger scans:
+
+```bash
+audiobook-organizer web
+```
+
+See [Local Web UI](GUI.md) for the browser workflow.
+
+## Safety Notes
+
+- Keep `--dry-run` in place until path mappings are correct.
+- Use a separate output directory for the first ABS organize run.
+- Keep `.abook-org.log` until ABS has scanned and you have verified the library.
+- Trigger an ABS scan after filesystem moves so the server reconciles changed paths.
+
+## Clean Up Missing ABS Items
+
+Audiobook Organizer moves files on disk; it does not directly rewrite Audiobookshelf database rows. After a non-dry-run organization, ABS may temporarily show missing items until the library scan and cleanup process reconciles the moved paths.
+
+If the library shows issues like missing books, open the ABS **Issues** view:
+
+![Audiobookshelf issues view showing missing books](issues.jpg)
+
+Then use the missing-books cleanup action:
+
+![Audiobookshelf remove missing books action](remove_books.jpg)
+
+If you enable the ABS library folder watcher, ABS may detect some path changes automatically. Even with the watcher enabled, a deliberate scan after filesystem moves is still the safer habit.

--- a/docs/development/docs-visuals.md
+++ b/docs/development/docs-visuals.md
@@ -1,0 +1,79 @@
+# Docs Visuals
+
+The docs visual workflow generates web UI screenshots, CLI terminal captures, CLI animated GIFs, and TUI animated GIFs/static final frames.
+
+## Asset Strategy
+
+Generated assets are not committed to git.
+
+- Pull requests upload `output/docs-visuals/**` as a short-lived GitHub Actions artifact for review.
+- `master` publishes the generated site and generated visuals to GitHub Pages.
+- Published visual URLs are deterministic under `assets/generated/`.
+
+Example stable paths after a `master` publish:
+
+```text
+https://jeeftor.github.io/audiobook-organizer/assets/generated/web-ui/web-ui-metadata-json-preview.png
+https://jeeftor.github.io/audiobook-organizer/assets/generated/cli/cli-organize-run.gif
+https://jeeftor.github.io/audiobook-organizer/assets/generated/tui/tui-organize-preview.gif
+```
+
+## Local Commands
+
+Generate all visuals:
+
+```bash
+make docs-visuals
+```
+
+Build the static docs site from current Markdown and generated visuals:
+
+```bash
+make docs-site
+```
+
+Verify links and required generated assets:
+
+```bash
+make docs-verify
+```
+
+Run the full publish-equivalent local path:
+
+```bash
+make docs-publish-site
+```
+
+## Focused Visual Generation
+
+Web UI screenshots:
+
+```bash
+make docs-web-screenshots
+```
+
+CLI static captures:
+
+```bash
+make docs-cli-captures
+```
+
+CLI animated GIFs:
+
+```bash
+make docs-cli-gifs
+```
+
+TUI captures:
+
+```bash
+make docs-tui-captures
+```
+
+On macOS, `make docs-tui-captures` builds and uses `audiobook-organizer-vhs:local` so VHS runs in Linux instead of launching the local Chrome app.
+
+## GitHub Pages
+
+The docs workflow should use GitHub Pages with the source set to GitHub Actions. The workflow builds visuals, builds `output/docs-site`, uploads the normal review artifact, then deploys the site on `master`.
+
+If Pages is disabled in repository settings, the workflow will still produce the review artifacts, but stable README image URLs will not update until Pages is enabled.

--- a/docs/explore-metadata.md
+++ b/docs/explore-metadata.md
@@ -1,0 +1,52 @@
+# Explore Metadata
+
+Use metadata exploration before organizing or renaming when titles, authors, series, tracks, discs, or narrators are missing or inconsistent.
+
+## Quick Inspection
+
+Text output:
+
+```bash
+audiobook-organizer metadata --dir=/books/source
+```
+
+JSON output:
+
+```bash
+audiobook-organizer metadata --dir=/books/source --json
+```
+
+Interactive exploration:
+
+```bash
+audiobook-organizer metadata-tui --dir=/books/source
+```
+
+## Sources To Check
+
+| Source | Use When |
+| --- | --- |
+| `metadata.json` | Each book folder already has sidecar metadata |
+| Embedded EPUB/MP3/M4B | Files carry useful title, author, series, or track tags |
+| Audiobookshelf | ABS already has cleaner metadata than the filesystem |
+| Field mapping | Metadata exists but uses non-standard field names |
+
+## Field Mapping
+
+If metadata exists under custom fields, map it instead of editing every file first:
+
+```bash
+audiobook-organizer \
+  --dir=/books/source \
+  --title-field=book_title \
+  --author-fields=authors,writer \
+  --dry-run
+```
+
+See [Metadata Sources](METADATA.md) for extraction details and [Metadata Command](METADATA_COMMAND.md) for command reference.
+
+## Next Steps
+
+- [Organize Audiobooks](organize.md)
+- [Rename Files](RENAME_FEATURE.md)
+- [Audiobookshelf](audiobookshelf.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,94 @@
+# Getting Started
+
+This guide walks through a safe first organization run. It uses a separate output directory so you can inspect the result before changing your source library.
+
+## Install
+
+Install from Homebrew, Go, Docker, or a release archive:
+
+```bash
+brew tap jeeftor/tap
+brew install audiobook-organizer
+```
+
+```bash
+go install github.com/jeeftor/audiobook-organizer@latest
+```
+
+See [Installation](INSTALLATION.md) for platform-specific options and package notes.
+
+## If You Use Audiobookshelf
+
+Before organizing an Audiobookshelf-managed library, enable **Store metadata with item** in the Audiobookshelf library settings. That setting writes a `metadata.json` file beside each book when ABS metadata is generated or updated.
+
+![Audiobookshelf setting for storing metadata.json files](store_metadata.jpg)
+
+Those sidecar files are the safest first metadata source for local organization because they keep the book-level title, author, series, narrator, and year data beside the audio files. After a non-dry-run organization, run or trigger an Audiobookshelf library scan so ABS can reconcile moved paths.
+
+See [Audiobookshelf](audiobookshelf.md) for cleanup screenshots, path mapping checks, and scan commands.
+
+## Choose A Small Source Folder
+
+Start with a small sample from your own library:
+
+```text
+/books/source/
+  The Case of Charles Dexter Ward/
+    metadata.json
+    01 - Chapter 1.mp3
+```
+
+Use a separate output folder for the first run:
+
+```text
+/books/organized/
+```
+
+## Preview First
+
+Run a dry run before moving files:
+
+```bash
+audiobook-organizer \
+  --dir=/books/source \
+  --out=/books/organized \
+  --dry-run \
+  --verbose
+```
+
+Check the planned destination paths, metadata warnings, and skipped books. Dry-run mode does not mutate the filesystem.
+
+## Run For Real
+
+When the preview looks right, remove `--dry-run`:
+
+```bash
+audiobook-organizer \
+  --dir=/books/source \
+  --out=/books/organized
+```
+
+The organizer writes `.abook-org.log` so the operation can be undone.
+
+## Undo If Needed
+
+Undo the last organization operation from the source directory:
+
+```bash
+audiobook-organizer --dir=/books/source --undo
+```
+
+Rename operations use a separate `.abook-rename.log` file:
+
+```bash
+audiobook-organizer rename --dir=/books/source --undo
+```
+
+See [Safety And Undo](safety-and-undo.md) for the invariants and log behavior.
+
+## Next Steps
+
+- Use [Layouts](LAYOUTS.md) to choose a directory structure.
+- Use [Metadata Sources](METADATA.md) if metadata is missing or stored in custom fields.
+- Use [Rename](RENAME_FEATURE.md) to standardize filenames after metadata is correct.
+- Use [Audiobookshelf](audiobookshelf.md) when your source of truth is an ABS server.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,102 @@
+<section class="doc-hero product-hero">
+  <div class="hero-copy">
+    <h1>Audiobook Organizer for Audiobookshelf (and More)</h1>
+    <p class="lead">Clean up audiobook folders with dry-run previews, metadata-aware layouts, rename templates, undo logs, and Audiobookshelf workflows.</p>
+    <div class="hero-actions">
+      <a class="button" href="getting-started.md">Start safely</a>
+      <a class="button secondary" href="interfaces.md">Choose workflow</a>
+    </div>
+  </div>
+  <figure class="hero-media">
+    <img src="assets/generated/web-ui/web-ui-metadata-json-preview.png" alt="Local web UI showing a metadata.json organize preview">
+    <figcaption>Browser review before files move</figcaption>
+  </figure>
+</section>
+
+Audiobook Organizer is for audiobook libraries that have drifted into inconsistent folder names, filenames, metadata sources, or Audiobookshelf paths. It lets you inspect what it can read, preview what it would change, run the operation, and keep an undo path while you verify the result.
+
+<section class="visual-grid" aria-label="Generated workflow demos">
+  <figure>
+    <img src="assets/generated/cli/cli-organize-run.gif" alt="Animated CLI organize run showing a full-cycle non-dry-run workflow">
+    <figcaption>Full-cycle CLI organization</figcaption>
+  </figure>
+  <figure>
+    <img src="assets/generated/tui/tui-organize-preview.gif" alt="Animated TUI organize preview workflow">
+    <figcaption>Interactive terminal preview</figcaption>
+  </figure>
+  <figure>
+    <img src="assets/generated/cli/cli-rename-preview.gif" alt="Animated CLI rename preview workflow">
+    <figcaption>Template rename preview</figcaption>
+  </figure>
+</section>
+
+## Audiobookshelf Users
+
+If Audiobookshelf is your metadata source, enable **Store metadata with item** before the first organize run. This writes a `metadata.json` sidecar beside each book so Audiobook Organizer can preview and organize from the same metadata ABS uses.
+
+![Audiobookshelf setting for storing metadata.json files](store_metadata.jpg)
+
+After a non-dry-run organization, trigger an Audiobookshelf scan and clean up any stale missing-book entries if ABS still points at old paths. See [Audiobookshelf](audiobookshelf.md) for the full setup and cleanup flow.
+
+## What It Does
+
+<section class="capability-grid" aria-label="Audiobook Organizer capabilities">
+  <article>
+    <h3>Organize</h3>
+    <p>Move or copy books into layouts such as <code>Author/Series/Title</code>, including custom layout templates.</p>
+  </article>
+  <article>
+    <h3>Rename Files</h3>
+    <p>Build filenames from title, author, series, track, disc, narrator, and other metadata fields.</p>
+  </article>
+  <article>
+    <h3>Explore Metadata</h3>
+    <p>Read <code>metadata.json</code>, embedded EPUB/MP3/M4B metadata, and Audiobookshelf metadata before changing files.</p>
+  </article>
+  <article>
+    <h3>Work safely</h3>
+    <p>Use dry-run previews, reviewed execution, skip/error summaries, and undo logs for organization and rename runs.</p>
+  </article>
+  <article>
+    <h3>Coordinate with ABS</h3>
+    <p>Discover Audiobookshelf libraries, test container-to-host path mappings, organize from ABS metadata, and trigger scans.</p>
+  </article>
+  <article>
+    <h3>Pick your interface</h3>
+    <p>Use the local web UI, scriptable CLI, keyboard-first TUI, rename flows, metadata tools, or ABS command group.</p>
+  </article>
+</section>
+
+## Start Here
+
+| Goal | Start Here |
+| --- | --- |
+| Install the binary | [Installation](INSTALLATION.md) |
+| Make a safe first run | [Getting Started](getting-started.md) |
+| Pick web UI, CLI, TUI, or ABS | [Choose An Interface](interfaces.md) |
+| Organize audiobooks | [Organize](organize.md) |
+| Rename files from metadata templates | [Rename Files](RENAME_FEATURE.md) |
+| Explore metadata before changing files | [Explore Metadata](explore-metadata.md) |
+| Configure Audiobookshelf `metadata.json` sidecars | [Audiobookshelf](audiobookshelf.md) |
+| Use the browser workflow | [Local Web UI](GUI.md) |
+| Work interactively in a terminal | [TUI](TUI.md) |
+| Organize with Audiobookshelf metadata | [Audiobookshelf](audiobookshelf.md) |
+| Understand dry-run and undo | [Safety And Undo](safety-and-undo.md) |
+| Choose metadata sources and mappings | [Metadata Sources](METADATA.md) |
+| Configure folder layouts | [Layouts](LAYOUTS.md) |
+| Configure defaults and environment variables | [Configuration](CONFIGURATION.md) |
+| See what changed between releases | [Changelog](../CHANGELOG.md) |
+| Troubleshoot a preview, rename, ABS path, or browser issue | [Troubleshooting](troubleshooting.md) |
+
+## First-Run Path
+
+<ol class="workflow-list">
+  <li><strong>Install</strong><span>Get the single <code>audiobook-organizer</code> binary.</span></li>
+  <li><strong>Choose</strong><span>Use web UI, CLI, TUI, rename, metadata, or ABS workflows.</span></li>
+  <li><strong>Preview</strong><span>Run a dry-run against a small source folder.</span></li>
+  <li><strong>Review</strong><span>Check planned paths and metadata warnings.</span></li>
+  <li><strong>Run</strong><span>Execute once the plan looks right.</span></li>
+  <li><strong>Undo</strong><span>Keep the generated log until you are satisfied.</span></li>
+</ol>
+
+See [Getting Started](getting-started.md) for exact commands.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,54 @@
+# Choose An Interface
+
+Audiobook Organizer ships one binary with browser, terminal, scriptable CLI, and Audiobookshelf workflows. Pick the interface based on how much review and automation you need.
+
+| Interface | Command | Best For | Notes |
+| --- | --- | --- | --- |
+| Local web UI | `audiobook-organizer web` | Visual setup, preview review, rename review, Audiobookshelf connection checks | Current GUI direction |
+| Organize | `audiobook-organizer --dir=/books` | Main workflow for repeatable scripts and batch runs | Use `--dry-run` first |
+| Organization TUI | `audiobook-organizer tui` | Keyboard-first interactive organization | Good when you want terminal review without browser setup |
+| Rename Files | `audiobook-organizer rename --dir=/books` | Scripted rename previews and execution | Template-driven |
+| Rename TUI | `audiobook-organizer rename-tui --dir=/books` | Interactive rename review | Supports field mapping and template preview |
+| Explore Metadata | `audiobook-organizer metadata --dir=/books` | Text-only metadata inspection | Use `--json` for machine-readable output |
+| Explore Metadata TUI | `audiobook-organizer metadata-tui --dir=/books` | Interactive metadata exploration | Useful before writing templates |
+| Audiobookshelf CLI | `audiobook-organizer abs ...` | ABS library discovery, path mapping, metadata organization, scans | Requires ABS URL/token |
+
+## Web UI
+
+Use the web UI when you want forms, staged review, selected moves/candidates, and visible backend summaries:
+
+```bash
+audiobook-organizer web
+```
+
+See [Local Web UI](GUI.md).
+
+## CLI
+
+Use organize for automation and repeatable runs:
+
+```bash
+audiobook-organizer --dir=/books/source --out=/books/organized --dry-run
+```
+
+See [Organize](organize.md) and [CLI](CLI.md).
+
+## TUI
+
+Use the TUI when you want an interactive terminal flow:
+
+```bash
+audiobook-organizer tui --dir=/books/source --out=/books/organized
+```
+
+See [TUI](TUI.md).
+
+## Audiobookshelf
+
+Use ABS workflows when the server already has the metadata you trust:
+
+```bash
+audiobook-organizer abs scan --abs-url=http://localhost:13378 --abs-token="$ABS_TOKEN"
+```
+
+See [Audiobookshelf](audiobookshelf.md).

--- a/docs/organize.md
+++ b/docs/organize.md
@@ -1,0 +1,66 @@
+# Organize Audiobooks
+
+Organize is the main Audiobook Organizer workflow. It previews and then moves or copies audiobook folders into consistent layouts using sidecar metadata, embedded metadata, or Audiobookshelf metadata.
+
+## Safe Organize Flow
+
+1. Choose a small source folder.
+2. Choose an output folder for the first run.
+3. Run a dry-run preview.
+4. Review planned destinations and warnings.
+5. Run the operation.
+6. Keep `.abook-org.log` until the result is verified.
+
+```bash
+audiobook-organizer \
+  --dir=/books/source \
+  --out=/books/organized \
+  --dry-run \
+  --verbose
+```
+
+When the plan is correct:
+
+```bash
+audiobook-organizer \
+  --dir=/books/source \
+  --out=/books/organized
+```
+
+## Common Layouts
+
+Use a built-in layout:
+
+```bash
+audiobook-organizer --dir=/books/source --layout=author-series-title --dry-run
+```
+
+Use a custom layout template:
+
+```bash
+audiobook-organizer \
+  --dir=/books/source \
+  --layout-template="{author}/{series}/{series-count} - {title}" \
+  --dry-run
+```
+
+See [Layouts](LAYOUTS.md) for built-in layouts and template fields.
+
+## Metadata Sources
+
+Organize can read:
+
+- `metadata.json`
+- embedded EPUB metadata
+- embedded MP3 tags
+- embedded M4B metadata
+- Audiobookshelf metadata
+
+See [Explore Metadata](explore-metadata.md) when the preview shows missing or incorrect fields.
+
+## Interfaces
+
+- Browser workflow: [Local Web UI](GUI.md)
+- Scriptable workflow: [CLI](CLI.md)
+- Interactive terminal workflow: [TUI](TUI.md)
+- ABS metadata workflow: [Audiobookshelf](audiobookshelf.md)

--- a/docs/safety-and-undo.md
+++ b/docs/safety-and-undo.md
@@ -1,0 +1,62 @@
+# Safety And Undo
+
+Audiobook Organizer is designed around preview-first workflows. The safest path is dry-run, review, execute, then keep the undo log until the library is verified.
+
+## Dry-Run Invariant
+
+Dry-run mode must not mutate the filesystem:
+
+```bash
+audiobook-organizer --dir=/books/source --out=/books/organized --dry-run
+```
+
+```bash
+audiobook-organizer rename --dir=/books/source --dry-run
+```
+
+Use dry-run output to inspect destination paths, skipped books, conflicts, and metadata warnings.
+
+## Organization Undo
+
+Organization operations write `.abook-org.log`.
+
+Undo from the same source directory:
+
+```bash
+audiobook-organizer --dir=/books/source --undo
+```
+
+Keep the log until you have verified the output folder and any Audiobookshelf scan results.
+
+## Rename Undo
+
+Rename operations write `.abook-rename.log`.
+
+Undo from the renamed directory:
+
+```bash
+audiobook-organizer rename --dir=/books/source --undo
+```
+
+## Safer First Runs
+
+1. Start with a small folder.
+2. Use a separate `--out` directory.
+3. Run with `--dry-run --verbose`.
+4. Fix missing metadata before execution.
+5. Run the real command.
+6. Verify the output.
+7. Keep the undo log until you no longer need rollback.
+
+## Riskier Options
+
+Use these only after the preview is understood:
+
+| Option | Risk |
+| --- | --- |
+| In-place organization with no `--out` | Source folders change directly |
+| `--remove-empty` | Empty source directories are removed after moves |
+| Large recursive source directories | More skipped/error cases can be hidden in long output |
+| Incorrect ABS path mapping | ABS metadata may point at paths the host cannot access |
+
+See [Getting Started](getting-started.md) for a safe first-run command sequence.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,70 @@
+# Troubleshooting
+
+## Dry Run Shows Missing Metadata
+
+Check the metadata source:
+
+- `metadata.json` should live beside the book files.
+- Embedded metadata requires `--use-embedded-metadata` or `--flat`.
+- Non-standard fields may need mapping flags such as `--title-field` or `--author-fields`.
+
+Use the metadata command to inspect what the organizer can read:
+
+```bash
+audiobook-organizer metadata --dir=/books/source
+```
+
+## Planned Paths Look Wrong
+
+Check the selected layout:
+
+```bash
+audiobook-organizer --dir=/books/source --layout=author-series-title --dry-run
+```
+
+For custom templates, inspect the field reference:
+
+```bash
+audiobook-organizer layout-template
+```
+
+See [Layouts](LAYOUTS.md).
+
+## Rename Conflicts
+
+Run rename in dry-run mode and inspect duplicate targets:
+
+```bash
+audiobook-organizer rename --dir=/books/source --dry-run
+```
+
+Use a template with enough unique fields, such as track or disc number.
+
+## Audiobookshelf Cannot Find Files
+
+Validate container-to-host path mapping:
+
+```bash
+audiobook-organizer abs scan \
+  --abs-url=http://localhost:13378 \
+  --abs-token="$ABS_TOKEN" \
+  --abs-path-map="/audiobooks:/mnt/media/audiobooks" \
+  --dir=/mnt/media/audiobooks \
+  --check-files
+```
+
+See [Audiobookshelf](audiobookshelf.md).
+
+## Browser Does Not Open
+
+Use `--no-open` and copy the printed local URL:
+
+```bash
+audiobook-organizer web --no-open
+```
+
+The server binds to `127.0.0.1` by default and uses a temporary token.
+
+## Docs Visual Generation Fails
+
+See [Docs Visuals](development/docs-visuals.md). On macOS, TUI VHS captures run through the local Docker image to avoid native Chrome crash dialogs.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "marked": "^18.0.4",
         "typescript": "^5.9.3",
         "vue-tsc": "^3.1.8"
       }
@@ -1159,6 +1160,19 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://artifacts.mitre.org:443/artifactory/api/npm/node-npm/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/muggle-string": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,8 +9,10 @@
     "preview": "vite preview --host 127.0.0.1",
     "docs:cli": "node scripts/capture-docs-cli.mjs",
     "docs:cli:gifs": "node scripts/capture-docs-cli-gifs.mjs",
+    "docs:site": "node scripts/build-docs-site.mjs",
     "docs:screenshots": "node scripts/capture-docs-screenshots.mjs",
     "docs:tui": "node scripts/capture-docs-tui.mjs",
+    "docs:verify": "node scripts/verify-docs.mjs",
     "install:browsers": "playwright install chromium",
     "test:e2e": "npm run build && playwright test",
     "test:e2e:headed": "npm run build && playwright test --headed",
@@ -24,6 +26,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "marked": "^18.0.4",
     "typescript": "^5.9.3",
     "vue-tsc": "^3.1.8"
   }

--- a/web/scripts/build-docs-site.mjs
+++ b/web/scripts/build-docs-site.mjs
@@ -1,0 +1,620 @@
+import { copyFile, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { dirname, extname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { marked } from 'marked'
+import { pages, siteBaseURL } from './docs-site-config.mjs'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(webRoot, '..')
+const siteRoot = join(repoRoot, 'output', 'docs-site')
+const generatedVisualsRoot = join(repoRoot, 'output', 'docs-visuals')
+const siteGeneratedRoot = join(siteRoot, 'assets', 'generated')
+const siteDocsAssetRoot = join(siteRoot, 'assets', 'docs')
+
+const outputBySource = new Map(
+  pages.map((page) => [normalizePath(page.source), page.output]),
+)
+
+marked.setOptions({
+  gfm: true,
+  headerIds: true,
+  mangle: false,
+})
+
+async function main() {
+  await rm(siteRoot, { recursive: true, force: true })
+  await mkdir(siteRoot, { recursive: true })
+  await copyStaticDocsAssets()
+  await copyGeneratedVisuals()
+
+  for (const page of pages) {
+    await renderPage(page)
+  }
+
+  await writeFile(join(siteRoot, 'robots.txt'), 'User-agent: *\nAllow: /\n')
+  await writeFile(join(siteRoot, 'sitemap.txt'), pages.map((page) => new URL(page.output, siteBaseURL).toString()).join('\n') + '\n')
+  console.log(`Wrote docs site to ${relative(repoRoot, siteRoot)}`)
+}
+
+async function renderPage(page) {
+  const sourcePath = join(repoRoot, page.source)
+  const markdown = await readFile(sourcePath, 'utf8')
+  const content = rewriteLinks(marked.parse(markdown), page)
+  const outputPath = join(siteRoot, page.output)
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, renderHTML(page, content))
+}
+
+function rewriteLinks(html, page) {
+  const rewritten = html
+    .replace(/href="([^"]+)"/g, (_match, href) => `href="${rewriteHref(href, page)}"`)
+    .replace(/src="([^"]+)"/g, (_match, src) => `src="${rewriteSrc(src, page)}"`)
+
+  return linkStandaloneImages(rewritten)
+}
+
+function rewriteHref(href, page) {
+  if (isExternal(href) || href.startsWith('#')) {
+    return href
+  }
+
+  const [rawPath, anchor = ''] = href.split('#')
+  const sourceDir = dirname(page.source)
+  const normalized = normalizePath(join(sourceDir, rawPath))
+
+  if (rawPath === '../README.md' || rawPath === 'README.md' || normalized === 'README.md') {
+    return `index.html${anchor ? `#${anchor}` : ''}`
+  }
+
+  const mapped = outputBySource.get(normalized)
+  if (mapped) {
+    return relativeURL(dirname(page.output), mapped, anchor)
+  }
+
+  if (rawPath.endsWith('.md')) {
+    return href
+  }
+
+  return href
+}
+
+function rewriteSrc(src, page) {
+  if (isExternal(src) || src.startsWith('#')) {
+    return src
+  }
+
+  if (src.startsWith('assets/generated/')) {
+    return relativeURL(dirname(page.output), src)
+  }
+
+  const normalized = normalizePath(join(dirname(page.source), src))
+  if (normalized.startsWith('docs/')) {
+    const assetPath = normalized.slice('docs/'.length)
+    return relativeURL(dirname(page.output), join('assets', 'docs', assetPath))
+  }
+
+  return src
+}
+
+function linkStandaloneImages(html) {
+  return html.replace(
+    /<p><img src="([^"]+)" alt="([^"]*)"><\/p>/g,
+    (_match, src, alt) => {
+      const href = imageHref(src)
+      return `<figure class="doc-image"><a href="${href}" target="_blank" rel="noopener"><img src="${src}" alt="${alt}"></a><figcaption><a href="${href}" target="_blank" rel="noopener">Open image</a></figcaption></figure>`
+    },
+  )
+}
+
+function imageHref(src) {
+  const docsAssetMatch = src.match(/assets\/docs\/([^#?]+)/)
+  if (docsAssetMatch) {
+    return `https://github.com/jeeftor/audiobook-organizer/blob/master/docs/${docsAssetMatch[1]}`
+  }
+  return src
+}
+
+function relativeURL(fromDir, target, anchor = '') {
+  const normalizedFrom = fromDir === '.' ? '' : fromDir
+  let url = normalizePath(relative(normalizedFrom || '.', target))
+  if (!url.startsWith('.')) {
+    url = `./${url}`
+  }
+  return `${url}${anchor ? `#${anchor}` : ''}`
+}
+
+function renderHTML(page, content) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHTML(page.title)} | Audiobook Organizer Docs</title>
+  <meta name="description" content="Audiobook Organizer for Audiobookshelf and local audiobook libraries. Preview, organize, rename, inspect metadata, choose layouts, use dry-run and undo workflows, and publish stable docs visuals.">
+  <link rel="stylesheet" href="${relativeURL(dirname(page.output), 'assets/site.css')}">
+</head>
+<body>
+  <a class="skip-link" href="#content">Skip to content</a>
+  <div class="layout">
+    <aside class="sidebar">
+      <a class="brand" href="${relativeURL(dirname(page.output), 'index.html')}">
+        <span class="brand-name">Audiobook Organizer</span>
+        <span class="brand-subtitle">Docs</span>
+      </a>
+      ${renderNav(page)}
+    </aside>
+    <main id="content" class="content">
+      ${content}
+      <footer class="site-footer">
+        These are AI-generated docs. Any errors are the AI's fault, obviously.
+        <a href="https://github.com/jeeftor/audiobook-organizer/issues">Open an issue</a>.
+      </footer>
+    </main>
+  </div>
+</body>
+</html>
+`
+}
+
+function renderNav(currentPage) {
+  const groups = new Map()
+  for (const page of pages) {
+    const group = groups.get(page.group) || []
+    group.push(page)
+    groups.set(page.group, group)
+  }
+
+  return Array.from(groups.entries())
+    .map(([groupName, groupPages]) => {
+      const links = groupPages.map((page) => {
+        const active = page.output === currentPage.output ? ' aria-current="page"' : ''
+        return `<a${active} href="${relativeURL(dirname(currentPage.output), page.output)}">${escapeHTML(page.title)}</a>`
+      }).join('\n')
+      return `<nav aria-label="${escapeHTML(groupName)}"><h2>${escapeHTML(groupName)}</h2>${links}</nav>`
+    })
+    .join('\n')
+}
+
+async function copyStaticDocsAssets() {
+  await mkdir(siteDocsAssetRoot, { recursive: true })
+  const entries = await readdir(join(repoRoot, 'docs'), { withFileTypes: true })
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue
+    }
+    if (!['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp'].includes(extname(entry.name).toLowerCase())) {
+      continue
+    }
+    await copyFile(join(repoRoot, 'docs', entry.name), join(siteDocsAssetRoot, entry.name))
+  }
+  await writeFile(join(siteRoot, 'assets', 'site.css'), siteCSS())
+}
+
+async function copyGeneratedVisuals() {
+  try {
+    const info = await stat(generatedVisualsRoot)
+    if (!info.isDirectory()) {
+      return
+    }
+  } catch {
+    return
+  }
+  await copyDirectory(generatedVisualsRoot, siteGeneratedRoot)
+}
+
+async function copyDirectory(source, target) {
+  await mkdir(target, { recursive: true })
+  const entries = await readdir(source, { withFileTypes: true })
+  for (const entry of entries) {
+    if (entry.name === '.DS_Store') {
+      continue
+    }
+    const sourcePath = join(source, entry.name)
+    const targetPath = join(target, entry.name)
+    if (entry.isDirectory()) {
+      await copyDirectory(sourcePath, targetPath)
+    } else if (entry.isFile()) {
+      await copyFile(sourcePath, targetPath)
+    }
+  }
+}
+
+function siteCSS() {
+  return `:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.55;
+  color: #182233;
+  background: #eef2f6;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+}
+
+a { color: #1260a8; }
+
+.skip-link {
+  position: absolute;
+  left: 16px;
+  top: -48px;
+  background: #172033;
+  color: white;
+  padding: 8px 12px;
+  z-index: 10;
+}
+
+.skip-link:focus { top: 16px; }
+
+.layout {
+  display: grid;
+  grid-template-columns: 268px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  border-right: 1px solid #1f2a3d;
+  background: #121a27;
+  padding: 20px 22px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: auto;
+}
+
+.brand {
+  display: grid;
+  gap: 2px;
+  padding: 2px 2px 18px;
+  border-bottom: 1px solid #d7deea;
+  text-decoration: none;
+  margin-bottom: 12px;
+}
+
+.brand-name {
+  color: #ffffff;
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 1.12;
+}
+
+.brand-subtitle {
+  color: #8fa1bb;
+  font-size: 12px;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+nav { margin: 0 0 24px; }
+nav h2 {
+  color: #8fa1bb;
+  font-size: 12px;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+nav a {
+  display: block;
+  color: #d7deea;
+  text-decoration: none;
+  padding: 7px 9px;
+  border-radius: 6px;
+  font-size: 14px;
+}
+nav a:hover,
+nav a[aria-current="page"] {
+  background: #213149;
+  color: #ffffff;
+}
+
+.content {
+  width: min(100%, 1120px);
+  padding: 46px 44px 86px;
+}
+
+h1, h2, h3 {
+  line-height: 1.2;
+  color: #101828;
+}
+
+h1 {
+  font-size: 42px;
+  margin: 0 0 18px;
+}
+
+h2 {
+  margin-top: 40px;
+  padding-top: 10px;
+  border-top: 1px solid #cdd6e2;
+}
+
+p, li { font-size: 16px; }
+
+.lead {
+  color: #d9e6f7;
+  font-size: 20px;
+  line-height: 1.45;
+  margin: 0 0 22px;
+}
+
+.doc-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(360px, 1fr);
+  gap: 28px;
+  align-items: center;
+  margin: 0 0 34px;
+  padding: 34px;
+  border-radius: 12px;
+  background: #172033;
+  color: #f8fafc;
+  box-shadow: 0 24px 70px rgb(23 32 51 / 18%);
+}
+
+.product-hero {
+  margin-bottom: 28px;
+}
+
+.doc-hero h1 {
+  color: #ffffff;
+  font-size: 48px;
+  margin-bottom: 14px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0 16px;
+  border-radius: 7px;
+  background: #48c6b0;
+  color: #0f172a;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.button.secondary {
+  background: transparent;
+  border: 1px solid #56677f;
+  color: #f8fafc;
+}
+
+.hero-media,
+.visual-grid figure {
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid #26364e;
+  border-radius: 10px;
+  background: #0f172a;
+  box-shadow: 0 14px 36px rgb(15 23 42 / 22%);
+}
+
+.hero-media img,
+.visual-grid img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  object-position: top left;
+  border-radius: 0;
+}
+
+.hero-media figcaption,
+.visual-grid figcaption {
+  padding: 10px 12px;
+  color: #d7deea;
+  font-size: 13px;
+  background: #121a27;
+}
+
+.visual-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin: 28px 0 34px;
+}
+
+.capability-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 22px 0 34px;
+}
+
+.capability-grid article {
+  min-height: 150px;
+  padding: 18px;
+  border: 1px solid #d1dae7;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgb(15 23 42 / 5%);
+}
+
+.capability-grid h3 {
+  margin: 0 0 9px;
+}
+
+.capability-grid p {
+  margin: 0;
+  color: #536176;
+}
+
+.workflow-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 0;
+  list-style: none;
+}
+
+.workflow-list li {
+  display: grid;
+  gap: 5px;
+  min-height: 118px;
+  padding: 16px;
+  border: 1px solid #d1dae7;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.workflow-list strong {
+  color: #101828;
+  font-size: 18px;
+}
+
+.workflow-list span {
+  color: #536176;
+}
+
+.doc-image {
+  margin: 22px 0;
+}
+
+.doc-image a:first-child {
+  display: block;
+}
+
+.doc-image img {
+  display: block;
+  border: 1px solid #d1dae7;
+  background: #ffffff;
+  box-shadow: 0 12px 30px rgb(15 23 42 / 10%);
+}
+
+.doc-image figcaption {
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.site-footer {
+  margin-top: 56px;
+  padding-top: 18px;
+  border-top: 1px solid #cdd6e2;
+  color: #627084;
+  font-size: 13px;
+}
+
+.site-footer a {
+  color: #1260a8;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  background: #ffffff;
+  box-shadow: 0 10px 28px rgb(15 23 42 / 6%);
+}
+
+th, td {
+  border: 1px solid #d9dee8;
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+th { background: #e8eef6; }
+
+code {
+  background: #edf0f5;
+  border-radius: 4px;
+  padding: 0.12em 0.28em;
+}
+
+pre {
+  overflow: auto;
+  padding: 16px;
+  border-radius: 8px;
+  background: #111827;
+  color: #f8fafc;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+@media (max-width: 860px) {
+  .layout { display: block; }
+  .sidebar {
+    position: sticky;
+    z-index: 5;
+    height: auto;
+    padding: 12px;
+    border-right: 0;
+    border-bottom: 1px solid #d9dee8;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+  .brand {
+    display: inline-block;
+    padding: 0;
+    border-bottom: 0;
+    margin: 0 12px 0 0;
+    vertical-align: middle;
+  }
+  .brand-name { font-size: 15px; }
+  .brand-subtitle { display: none; }
+  .sidebar nav {
+    display: contents;
+  }
+  .sidebar nav h2 {
+    display: none;
+  }
+  .sidebar nav a {
+    display: inline-flex;
+    margin-right: 4px;
+  }
+  .content { padding: 32px 20px 64px; }
+  h1 { font-size: 34px; }
+  .doc-hero {
+    grid-template-columns: 1fr;
+    padding: 24px;
+  }
+  .doc-hero h1 { font-size: 36px; }
+  .visual-grid,
+  .capability-grid,
+  .workflow-list {
+    grid-template-columns: 1fr;
+  }
+}
+`
+}
+
+function normalizePath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '')
+}
+
+function isExternal(value) {
+  return /^(https?:|mailto:|tel:)/.test(value)
+}
+
+function escapeHTML(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error(error)
+  process.exitCode = 1
+}

--- a/web/scripts/capture-docs-cli-gifs.mjs
+++ b/web/scripts/capture-docs-cli-gifs.mjs
@@ -84,12 +84,34 @@ async function assertVHS() {
 }
 
 async function runVHS(capture) {
-  await runCommand('vhs', ['-q', join(tapeDir, capture.tape)], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      NO_COLOR: '1',
-    },
+  const attempts = 3
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await runCommand('vhs', ['-q', join(tapeDir, capture.tape)], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          NO_COLOR: '1',
+        },
+      })
+      return
+    } catch (error) {
+      if (attempt === attempts || !isRetryableVHSError(error)) {
+        throw error
+      }
+      await delay(1000 * attempt)
+    }
+  }
+}
+
+function isRetryableVHSError(error) {
+  const message = String(error?.message || error)
+  return message.includes('could not open ttyd') || message.includes('net::ERR_EMPTY_RESPONSE')
+}
+
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
   })
 }
 

--- a/web/scripts/capture-docs-screenshots.mjs
+++ b/web/scripts/capture-docs-screenshots.mjs
@@ -10,6 +10,7 @@ const webRoot = resolve(scriptDir, '..')
 const repoRoot = resolve(webRoot, '..')
 const screenshotDir = join(repoRoot, 'output', 'docs-visuals', 'web-ui')
 const sampleRoot = join(repoRoot, 'output', 'docs-web-ui-sample')
+const goBuildCache = process.env.GOCACHE || join(repoRoot, 'output', 'go-build-cache')
 const metadataSourceDir = 'output/docs-web-ui-sample/metadata-json/source'
 const metadataOutputDir = 'output/docs-web-ui-sample/metadata-json/organized'
 const embeddedSourceDir = 'output/docs-web-ui-sample/embedded/source'
@@ -165,7 +166,10 @@ async function startWebServer() {
   const child = spawn('go', ['run', '.', 'web', '--host', '127.0.0.1', '--port', '0', '--no-open'], {
     cwd: repoRoot,
     detached: process.platform !== 'win32',
-    env: process.env,
+    env: {
+      ...process.env,
+      GOCACHE: goBuildCache,
+    },
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 

--- a/web/scripts/docs-site-config.mjs
+++ b/web/scripts/docs-site-config.mjs
@@ -1,0 +1,141 @@
+export const siteBaseURL = 'https://jeeftor.github.io/audiobook-organizer/'
+
+export const pages = [
+  {
+    source: 'docs/index.md',
+    output: 'index.html',
+    title: 'Audiobook Organizer for Audiobookshelf',
+    group: 'Start',
+  },
+  {
+    source: 'docs/INSTALLATION.md',
+    output: 'installation.html',
+    title: 'Installation',
+    group: 'Start',
+  },
+  {
+    source: 'docs/getting-started.md',
+    output: 'getting-started.html',
+    title: 'Getting Started',
+    group: 'Start',
+  },
+  {
+    source: 'docs/interfaces.md',
+    output: 'interfaces.html',
+    title: 'Choose An Interface',
+    group: 'Start',
+  },
+  {
+    source: 'docs/GUI.md',
+    output: 'web-ui.html',
+    title: 'Local Web UI',
+    group: 'Interfaces',
+  },
+  {
+    source: 'docs/CLI.md',
+    output: 'cli.html',
+    title: 'CLI',
+    group: 'Interfaces',
+  },
+  {
+    source: 'docs/TUI.md',
+    output: 'tui.html',
+    title: 'TUI',
+    group: 'Interfaces',
+  },
+  {
+    source: 'docs/organize.md',
+    output: 'organize.html',
+    title: 'Organize',
+    group: 'Workflows',
+  },
+  {
+    source: 'docs/RENAME_FEATURE.md',
+    output: 'rename.html',
+    title: 'Rename Files',
+    group: 'Workflows',
+  },
+  {
+    source: 'docs/explore-metadata.md',
+    output: 'explore-metadata.html',
+    title: 'Explore Metadata',
+    group: 'Workflows',
+  },
+  {
+    source: 'docs/audiobookshelf.md',
+    output: 'audiobookshelf.html',
+    title: 'Audiobookshelf',
+    group: 'Workflows',
+  },
+  {
+    source: 'docs/safety-and-undo.md',
+    output: 'safety-and-undo.html',
+    title: 'Safety And Undo',
+    group: 'Workflows',
+  },
+  {
+    source: 'docs/METADATA.md',
+    output: 'metadata.html',
+    title: 'Metadata Sources',
+    group: 'Reference',
+  },
+  {
+    source: 'docs/METADATA_COMMAND.md',
+    output: 'metadata-command.html',
+    title: 'Metadata Command',
+    group: 'Reference',
+  },
+  {
+    source: 'docs/LAYOUTS.md',
+    output: 'layouts.html',
+    title: 'Layouts',
+    group: 'Reference',
+  },
+  {
+    source: 'docs/CONFIGURATION.md',
+    output: 'configuration.html',
+    title: 'Configuration',
+    group: 'Reference',
+  },
+  {
+    source: 'CHANGELOG.md',
+    output: 'changelog.html',
+    title: 'Changelog',
+    group: 'Reference',
+  },
+  {
+    source: 'docs/troubleshooting.md',
+    output: 'troubleshooting.html',
+    title: 'Troubleshooting',
+    group: 'Reference',
+  },
+  {
+    source: 'docs/development/docs-visuals.md',
+    output: 'development/docs-visuals.html',
+    title: 'Docs Visuals',
+    group: 'Development',
+  },
+  {
+    source: 'docs/GUI_TESTING.md',
+    output: 'development/web-ui-testing.html',
+    title: 'Web UI Testing',
+    group: 'Development',
+  },
+]
+
+export const requiredGeneratedAssets = [
+  'web-ui/web-ui-metadata-json-preview.png',
+  'web-ui/web-ui-metadata-json-review.png',
+  'cli/cli-help.png',
+  'cli/cli-organize-run.gif',
+  'cli/cli-rename-preview.gif',
+  'tui/tui-organize-preview.gif',
+  'tui/tui-organize-preview.png',
+]
+
+export const requiredHomepageGeneratedAssets = [
+  'assets/generated/web-ui/web-ui-metadata-json-preview.png',
+  'assets/generated/cli/cli-organize-run.gif',
+  'assets/generated/cli/cli-rename-preview.gif',
+  'assets/generated/tui/tui-organize-preview.gif',
+]

--- a/web/scripts/verify-docs.mjs
+++ b/web/scripts/verify-docs.mjs
@@ -1,0 +1,145 @@
+import { access, readFile, readdir, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { pages, requiredGeneratedAssets, requiredHomepageGeneratedAssets } from './docs-site-config.mjs'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(webRoot, '..')
+const siteRoot = join(repoRoot, 'output', 'docs-site')
+const failures = []
+
+async function main() {
+  await verifyMarkdownSources()
+  await verifyMarkdownLinks()
+  await verifySiteOutput()
+  await verifyGeneratedAssets()
+  await verifyHomepageVisualReferences()
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`docs verify: ${failure}`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.log('Docs verification passed.')
+}
+
+async function verifyHomepageVisualReferences() {
+  const homepagePath = join(siteRoot, 'index.html')
+  let homepage
+  try {
+    homepage = await readFile(homepagePath, 'utf8')
+  } catch {
+    failures.push('missing generated homepage for visual reference verification')
+    return
+  }
+
+  for (const asset of requiredHomepageGeneratedAssets) {
+    if (!homepage.includes(asset)) {
+      failures.push(`generated homepage does not reference ${asset}`)
+    }
+  }
+}
+
+async function verifyMarkdownSources() {
+  for (const page of pages) {
+    await expectFile(join(repoRoot, page.source), `missing docs source ${page.source}`)
+  }
+}
+
+async function verifyMarkdownLinks() {
+  const docsFiles = await listMarkdownFiles(join(repoRoot, 'docs'))
+  docsFiles.push(join(repoRoot, 'README.md'))
+
+  for (const file of docsFiles) {
+    const markdown = await readFile(file, 'utf8')
+    const links = Array.from(markdown.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)).map((match) => match[1])
+    for (const link of links) {
+      await verifyMarkdownLink(file, link)
+    }
+  }
+}
+
+async function verifyMarkdownLink(file, link) {
+  if (link.startsWith('#') || /^(https?:|mailto:|tel:)/.test(link)) {
+    return
+  }
+
+  const [target] = link.split('#')
+  if (!target || target.startsWith('data:')) {
+    return
+  }
+
+  const resolved = resolve(dirname(file), target)
+  try {
+    await access(resolved)
+  } catch {
+    failures.push(`${relativePath(file)} links to missing local target ${link}`)
+  }
+}
+
+async function verifySiteOutput() {
+  for (const page of pages) {
+    await expectFile(join(siteRoot, page.output), `missing generated site page ${page.output}`)
+  }
+  await expectFile(join(siteRoot, 'assets', 'site.css'), 'missing generated site stylesheet')
+}
+
+async function verifyGeneratedAssets() {
+  const generatedRoot = join(siteRoot, 'assets', 'generated')
+  try {
+    const info = await stat(generatedRoot)
+    if (!info.isDirectory()) {
+      return
+    }
+  } catch {
+    console.log('Docs verification skipped generated visual asset checks because output/docs-site/assets/generated does not exist.')
+    return
+  }
+
+  for (const asset of requiredGeneratedAssets) {
+    await expectFile(
+      join(generatedRoot, asset),
+      `missing generated visual asset assets/generated/${asset}`,
+    )
+  }
+}
+
+async function expectFile(path, message) {
+  try {
+    const info = await stat(path)
+    if (!info.isFile()) {
+      failures.push(message)
+    }
+  } catch {
+    failures.push(message)
+  }
+}
+
+async function listMarkdownFiles(root) {
+  const files = []
+  const entries = await readdir(root, { withFileTypes: true })
+  for (const entry of entries) {
+    const path = join(root, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...await listMarkdownFiles(path))
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+function relativePath(path) {
+  return path.replace(`${repoRoot}/`, '')
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error(error)
+  process.exitCode = 1
+}


### PR DESCRIPTION
Resolves #151.

Summary:
- Reworks README as a concise landing page while keeping the Audiobookshelf metadata.json setup and screenshot prominent.
- Adds a generated GitHub Pages docs site with user-facing guides for getting started, workflows, Audiobookshelf, safety/undo, troubleshooting, and docs visuals.
- Publishes generated screenshots/GIFs to stable docs paths and verifies homepage references.
- Adds retry handling for transient VHS ttyd startup failures during CLI GIF capture.

Validation:
- make docs-publish-site
- make docs-verify
- prek run --all-files
- git diff --check

Docs/changelog:
- README, docs site, install docs, and CHANGELOG.md updated.