### PR TITLE
docs: restore practical README task guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ Organization writes `.abook-org.log`; rename writes `.abook-rename.log`. Keep th
 
 Full comparison: [Choose An Interface](docs/interfaces.md).
 
+## Common Tasks
+
+| Task | Use |
+| --- | --- |
+| Organize books into `Author/Series/Title` | `audiobook-organizer --dir=/books --layout=author-series-title --dry-run` |
+| Rename files from title, author, series, track, or disc fields | `audiobook-organizer rename --dir=/books --dry-run` |
+| No `metadata.json`, but audio files have tags | `audiobook-organizer --dir=/books --use-embedded-metadata --dry-run` |
+| Flat folder of individual audiobooks | `audiobook-organizer --dir=/books --flat --dry-run` |
+| MP3 tags use non-standard fields | map fields with `--author-fields`, `--title-field`, `--series-field`, `--track-field`, or `--disc-field` |
+| Previous organization needs to be reverted | `audiobook-organizer --dir=/books --undo` |
+
+See [Organize](docs/organize.md), [Explore Metadata](docs/explore-metadata.md), [Metadata Sources](docs/METADATA.md), and [Safety And Undo](docs/safety-and-undo.md).
+
 ## Common Commands
 
 Start the local browser UI:

--- a/docs/explore-metadata.md
+++ b/docs/explore-metadata.md
@@ -31,6 +31,28 @@ audiobook-organizer metadata-tui --dir=/books/source
 | Audiobookshelf | ABS already has cleaner metadata than the filesystem |
 | Field mapping | Metadata exists but uses non-standard field names |
 
+## How To Decide
+
+Use the normal organize command first when every book directory has a useful `metadata.json` file:
+
+```bash
+audiobook-organizer --dir=/books/source --dry-run
+```
+
+Use embedded metadata when there are no sidecar files but the audio files have EPUB, MP3, or M4B tags:
+
+```bash
+audiobook-organizer --dir=/books/source --use-embedded-metadata --dry-run
+```
+
+Use flat mode when a folder contains individual audiobook files rather than one directory per book:
+
+```bash
+audiobook-organizer --dir=/books/source --flat --dry-run
+```
+
+Use field mapping when the preview finds metadata but puts the wrong values in author, title, series, track, or disc fields.
+
 ## Field Mapping
 
 If metadata exists under custom fields, map it instead of editing every file first:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,6 +44,14 @@ Use a separate output folder for the first run:
 /books/organized/
 ```
 
+If the source folder does not have `metadata.json` files, inspect embedded metadata before organizing:
+
+```bash
+audiobook-organizer metadata --dir=/books/source --use-embedded-metadata
+```
+
+For a flat folder of individual audiobook files, preview with `--flat` instead of the default directory-as-book behavior.
+
 ## Preview First
 
 Run a dry run before moving files:

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,18 @@ Audiobook Organizer is for audiobook libraries that have drifted into inconsiste
   </figure>
 </section>
 
+## Common Tasks
+
+| Task | Start With |
+| --- | --- |
+| Organize books into `Author/Series/Title` | [Organize](organize.md) |
+| Rename files from title, author, series, track, or disc fields | [Rename Files](RENAME_FEATURE.md) |
+| Use Audiobookshelf-created `metadata.json` files | [Audiobookshelf](audiobookshelf.md) |
+| No `metadata.json`, but audio files have tags | [Explore Metadata](explore-metadata.md) |
+| MP3 tags use non-standard fields | [Metadata Sources](METADATA.md#field-mapping) |
+| Previous organization or rename needs to be reverted | [Safety And Undo](safety-and-undo.md) |
+| Planned paths look wrong | [Troubleshooting](troubleshooting.md) |
+
 ## Audiobookshelf Users
 
 If Audiobookshelf is your metadata source, enable **Store metadata with item** before the first organize run. This writes a `metadata.json` sidecar beside each book so Audiobook Organizer can preview and organize from the same metadata ABS uses.


### PR DESCRIPTION
Resolves #155.

Summary:
- Compares older README guidance against the current README/docs and restores the practical task-routing pieces that were still weaker.
- Adds a concise README Common Tasks table for organize, rename, embedded metadata, flat folders, field mapping, and undo.
- Adds the same task routing to the generated docs homepage.
- Expands Explore Metadata with source-selection commands and Getting Started with no-sidecar/flat-folder guidance.

Validation:
- make docs-verify
- git diff --check
- prek run --all-files

Docs/changelog:
- README and user docs updated; no changelog entry because this is a follow-up docs refinement under the existing docs overhaul.