### PR TITLE
docs: overhaul installation guide setup

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,27 +1,50 @@
 # Installation Guide
 
-Audiobook Organizer ships as one binary named `audiobook-organizer`. The same binary provides the CLI, TUI, Audiobookshelf commands, and local browser-based web UI.
+Audiobook Organizer ships as one binary named `audiobook-organizer`. Install the binary first, then configure your metadata source before moving files.
 
-## Commands
+## Pre-Requirement: Configure Audiobookshelf
 
-| Command | Mode | Description |
-|---------|------|-------------|
-| `audiobook-organizer web` | Local Web UI | Starts a localhost server and opens the browser UI |
-| `audiobook-organizer gui` | Local Web UI alias | Compatibility alias for `web` |
-| `audiobook-organizer tui` | Interactive Terminal | Keyboard-driven terminal workflow |
-| `audiobook-organizer rename-tui` | Rename TUI | Interactive rename workflow |
-| `audiobook-organizer metadata` | Metadata CLI | Text-only metadata inspection |
-| `audiobook-organizer metadata-tui` | Metadata TUI | Interactive metadata exploration |
-| `audiobook-organizer abs` | Audiobookshelf CLI | ABS libraries, mappings, item loading, and scan triggers |
-| `audiobook-organizer --dir=/path` | CLI | Scriptable organization |
+<section class="media-callout">
+  <a class="media-callout-image" href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/store_metadata.jpg" target="_blank" rel="noopener">
+    <img src="store_metadata.jpg" alt="Audiobookshelf setting for storing metadata.json files">
+  </a>
+  <div class="media-callout-copy">
+    <p>If you use Audiobookshelf, this is the important setup step before the first organize run. Configure ABS to write <code>metadata.json</code> sidecars into the same directories as your books.</p>
+    <p>In the Audiobookshelf library settings, enable <strong>Store metadata with item</strong>.</p>
+    <p>When that setting is enabled, Audiobookshelf writes a <code>metadata.json</code> file beside each book when metadata is generated or updated.</p>
+  </div>
+</section>
+
+```text
+/audiobooks/The Case of Charles Dexter Ward/
+  metadata.json
+  01 - Chapter 1.mp3
+  02 - Chapter 2.mp3
+```
+
+Those sidecars give Audiobook Organizer a stable book-level source for title, author, series, narrator, and year. If your library does not have `metadata.json` files, use embedded metadata mode instead. See [Audiobookshelf](audiobookshelf.md) for the full ABS setup and cleanup flow, or [Explore Metadata](explore-metadata.md) to decide which metadata source to use.
+
+After a real organize run, Audiobookshelf may show old paths as missing until it scans and reconciles moved files. The **Enable folder watcher for library** setting may help, but you should still trigger a scan and clean up stale missing-book entries when needed. See [Audiobookshelf](audiobookshelf.md#clean-up-missing-abs-items).
+
+## Install Audiobook Organizer
+
+## Direct Download From GitHub
+
+Download the latest release for your platform from:
+
+<https://github.com/jeeftor/audiobook-organizer/releases/latest>
+
+Use this option when you want a release archive or package file without Homebrew, Go, or Docker. After downloading, extract the archive or install the package, then verify the binary:
+
+```bash
+audiobook-organizer version
+```
 
 ## macOS
 
 ```bash
 brew tap jeeftor/tap
 brew install audiobook-organizer
-
-audiobook-organizer web
 ```
 
 You can also download the macOS archive from GitHub Releases and place the `audiobook-organizer` binary somewhere on your `PATH`.
@@ -39,8 +62,6 @@ sudo dnf install ./audiobook-organizer-*.x86_64.rpm
 
 # Alpine .apk package
 sudo apk add --allow-untrusted ./audiobook-organizer-*.apk
-
-audiobook-organizer web
 ```
 
 The web UI runs in your existing browser and does not require native desktop runtime packages.
@@ -50,14 +71,7 @@ The web UI runs in your existing browser and does not require native desktop run
 Download `audiobook-organizer-windows-amd64.zip` from GitHub Releases, extract it, and run:
 
 ```powershell
-.\audiobook-organizer.exe web
-```
-
-For terminal workflows:
-
-```powershell
-.\audiobook-organizer.exe tui
-.\audiobook-organizer.exe --dir C:\Audiobooks --out C:\Organized --dry-run
+.\audiobook-organizer.exe version
 ```
 
 ## Docker
@@ -79,7 +93,6 @@ The local web UI is primarily intended for host installs. For Docker, prefer CLI
 go install github.com/jeeftor/audiobook-organizer@latest
 
 audiobook-organizer version
-audiobook-organizer web
 ```
 
 ## Build From Source
@@ -104,10 +117,15 @@ make test
 ```bash
 audiobook-organizer version
 audiobook-organizer --help
-audiobook-organizer web --help
-audiobook-organizer tui --help
-audiobook-organizer abs --help
 ```
+
+## Choose A First Workflow
+
+After installation and metadata setup:
+
+- Use [Getting Started](getting-started.md) for a safe dry-run first pass.
+- Use [Choose An Interface](interfaces.md) to pick web UI, CLI, TUI, rename, metadata, or ABS workflows.
+- Use [Audiobookshelf](audiobookshelf.md) when ABS metadata, path mapping, scans, or missing-item cleanup are involved.
 
 ## Troubleshooting
 
@@ -117,7 +135,7 @@ Make sure the directory containing `audiobook-organizer` is on your `PATH`.
 
 ### Browser Does Not Open
 
-Run with `--no-open`, copy the printed URL, and open it manually:
+If the browser UI does not open automatically, run it with `--no-open`, copy the printed URL, and open it manually:
 
 ```bash
 audiobook-organizer web --no-open
@@ -141,8 +159,8 @@ audiobook-organizer --dir=/books --out=/organized --dry-run
 
 ## See Also
 
-- [CLI.md](CLI.md) - Command-line usage
-- [GUI.md](GUI.md) - Local Web UI guide
-- [TUI.md](TUI.md) - Terminal UI guide
-- [CONFIGURATION.md](CONFIGURATION.md) - Configuration file setup
+- [Getting Started](getting-started.md) - Safe first run
+- [Audiobookshelf](audiobookshelf.md) - ABS metadata setup, scans, and cleanup
+- [Choose An Interface](interfaces.md) - Web UI, CLI, TUI, rename, metadata, and ABS workflows
+- [Configuration](CONFIGURATION.md) - Configuration file setup
 - [Main README](../README.md) - Project overview

--- a/web/scripts/build-docs-site.mjs
+++ b/web/scripts/build-docs-site.mjs
@@ -495,6 +495,35 @@ p, li { font-size: 16px; }
   font-size: 13px;
 }
 
+.media-callout {
+  display: grid;
+  grid-template-columns: minmax(260px, 420px) minmax(0, 1fr);
+  gap: 22px;
+  align-items: start;
+  margin: 22px 0;
+}
+
+.media-callout-image {
+  display: block;
+}
+
+.media-callout-image img {
+  display: block;
+  width: 100%;
+  border: 1px solid #d1dae7;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 12px 30px rgb(15 23 42 / 10%);
+}
+
+.media-callout-copy {
+  padding-top: 2px;
+}
+
+.media-callout-copy p:first-child {
+  margin-top: 0;
+}
+
 .site-footer {
   margin-top: 56px;
   padding-top: 18px;
@@ -589,7 +618,8 @@ img {
   .doc-hero h1 { font-size: 36px; }
   .visual-grid,
   .capability-grid,
-  .workflow-list {
+  .workflow-list,
+  .media-callout {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
Follow-up for #155.

Summary:
- Reworks the installation guide so it starts with the Audiobookshelf metadata.json pre-requirement from the v0.9.24 README concept.
- Uses HTML/CSS to render the ABS settings screenshot smaller with explanatory text to the right on desktop and stacked on mobile.
- Adds a Direct Download from GitHub section linking to the latest release.
- Removes the command inventory from installation and routes readers to Getting Started, Choose An Interface, and Audiobookshelf workflow docs.

Validation:
- make docs-verify
- node --check web/scripts/build-docs-site.mjs
- git diff --check
- commit hooks