### PR TITLE
fix: use public npm tarball for docs build

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1164,7 +1164,7 @@
     },
     "node_modules/marked": {
       "version": "18.0.4",
-      "resolved": "https://artifacts.mitre.org:443/artifactory/api/npm/node-npm/marked/-/marked-18.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
       "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
Follow-up for the docs site publishing failure after #158.

Summary:
- Updates the `marked` package-lock resolved URL from the internal MITRE npm proxy to the public npm registry.
- GitHub-hosted runners cannot resolve `artifacts.mitre.org`, causing the Docs Visuals workflow to fail during `npm ci` and preventing Pages docs from regenerating.

Validation:
- `npm ci` in `web/`
- `make docs-verify`
- `git diff --check`
- commit hooks
