### PR TITLE
docs: surface ABS lifecycle in getting started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refined the local web UI iterative flow so setup option changes auto-refresh previews and review/run selection share one final workflow stage.
 - Improved local web UI manual testing with a reusable template builder, colored layout/rename fields, relative local preview paths, completed move lists after execution, and automatic fallback from missing `metadata.json` previews to embedded file metadata.
 - Updated the layout guide and docs workflow to use public-domain book examples and added more table-based layout guidance.
+- Surfaced the Audiobookshelf lifecycle diagram on Getting Started and made the ABS metadata settings screenshot a compact side-by-side callout.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refined the local web UI iterative flow so setup option changes auto-refresh previews and review/run selection share one final workflow stage.
 - Improved local web UI manual testing with a reusable template builder, colored layout/rename fields, relative local preview paths, completed move lists after execution, and automatic fallback from missing `metadata.json` previews to embedded file metadata.
 - Updated the layout guide and docs workflow to use public-domain book examples and added more table-based layout guidance.
-- Surfaced the Audiobookshelf lifecycle diagram on Getting Started and made the ABS metadata settings screenshot a compact side-by-side callout.
+- Surfaced the Audiobookshelf lifecycle and missing-item cleanup screenshots on Getting Started and made the ABS metadata settings screenshot a compact side-by-side callout.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,23 @@ The normal ABS cycle is: configure sidecar metadata, preview, organize, scan ABS
 
 ![Audiobookshelf organize lifecycle](abs-organize-lifecycle.svg)
 
+After the scan, ABS may still list old filesystem paths as missing. That is a normal cleanup step after moving files, not a failed organize run. Review the missing items in ABS, then use the missing-books cleanup action when the organized paths are already visible in the library.
+
+<section class="image-pair" aria-label="Audiobookshelf missing item cleanup screenshots">
+  <figure>
+    <a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/issues.jpg" target="_blank" rel="noopener">
+      <img src="issues.jpg" alt="Audiobookshelf issues view showing missing books">
+    </a>
+    <figcaption><a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/issues.jpg" target="_blank" rel="noopener">Open image</a> - review missing old paths in the ABS Issues view.</figcaption>
+  </figure>
+  <figure>
+    <a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/remove_books.jpg" target="_blank" rel="noopener">
+      <img src="remove_books.jpg" alt="Audiobookshelf remove missing books action">
+    </a>
+    <figcaption><a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/remove_books.jpg" target="_blank" rel="noopener">Open image</a> - remove missing entries after ABS has found the organized files.</figcaption>
+  </figure>
+</section>
+
 See [Audiobookshelf](audiobookshelf.md) for cleanup screenshots, path mapping checks, and scan commands.
 
 ## Choose A Small Source Folder

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,11 +19,20 @@ See [Installation](INSTALLATION.md) for platform-specific options and package no
 
 ## If You Use Audiobookshelf
 
-Before organizing an Audiobookshelf-managed library, enable **Store metadata with item** in the Audiobookshelf library settings. That setting writes a `metadata.json` file beside each book when ABS metadata is generated or updated.
+<section class="media-callout">
+  <a class="media-callout-image" href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/store_metadata.jpg" target="_blank" rel="noopener">
+    <img src="store_metadata.jpg" alt="Audiobookshelf setting for storing metadata.json files">
+  </a>
+  <div class="media-callout-copy">
+    <p>Before organizing an Audiobookshelf-managed library, enable <strong>Store metadata with item</strong> in the Audiobookshelf library settings.</p>
+    <p>That setting writes a <code>metadata.json</code> file beside each book when ABS metadata is generated or updated.</p>
+    <p>Those sidecar files are the safest first metadata source for local organization because they keep the book-level title, author, series, narrator, and year data beside the audio files.</p>
+  </div>
+</section>
 
-![Audiobookshelf setting for storing metadata.json files](store_metadata.jpg)
+The normal ABS cycle is: configure sidecar metadata, preview, organize, scan ABS, clean up old missing paths if ABS still reports them, and keep the undo log until the library is verified.
 
-Those sidecar files are the safest first metadata source for local organization because they keep the book-level title, author, series, narrator, and year data beside the audio files. After a non-dry-run organization, run or trigger an Audiobookshelf library scan so ABS can reconcile moved paths.
+![Audiobookshelf organize lifecycle](abs-organize-lifecycle.svg)
 
 See [Audiobookshelf](audiobookshelf.md) for cleanup screenshots, path mapping checks, and scan commands.
 

--- a/web/scripts/build-docs-site.mjs
+++ b/web/scripts/build-docs-site.mjs
@@ -524,6 +524,39 @@ p, li { font-size: 16px; }
   margin-top: 0;
 }
 
+.image-pair {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.72fr) minmax(260px, 1fr);
+  gap: 18px;
+  align-items: start;
+  margin: 22px 0;
+}
+
+.image-pair figure {
+  margin: 0;
+}
+
+.image-pair img {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  max-height: 260px;
+  border: 1px solid #d1dae7;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 12px 30px rgb(15 23 42 / 10%);
+}
+
+.image-pair figcaption {
+  margin-top: 8px;
+  color: #536176;
+  font-size: 13px;
+}
+
+.image-pair figcaption a {
+  color: #1260a8;
+}
+
 .site-footer {
   margin-top: 56px;
   padding-top: 18px;
@@ -619,6 +652,7 @@ img {
   .visual-grid,
   .capability-grid,
   .workflow-list,
+  .image-pair,
   .media-callout {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
Resolves #155.

## Summary
- Replaces the full-width Getting Started Audiobookshelf settings screenshot with the compact side-by-side callout used by Installation.
- Adds the Audiobookshelf organize lifecycle diagram directly to Getting Started before the first-run source folder steps.
- Adds a changelog note for the visible docs update.

## Verification
- `make docs-verify`
- `git diff --check`
- Rendered `output/docs-site/getting-started.html` with Chrome Headless Shell and reviewed the screenshot locally.

## Docs / Changelog
- Updated `docs/getting-started.md`.
- Updated `CHANGELOG.md`.
