### PR TITLE
docs: align getting started with ABS flow

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,12 @@
 
 This guide walks through a safe first organization run. It uses a separate output directory so you can inspect the result before changing your source library.
 
+## Audiobookshelf First-Run Flow
+
+For Audiobookshelf-managed libraries, use this cycle: configure sidecar metadata, preview, organize, scan ABS, clean up old missing paths if ABS still reports them, and keep the undo log until the library is verified.
+
+![Audiobookshelf organize lifecycle](abs-organize-lifecycle.svg)
+
 ## Install
 
 Install from Homebrew, Go, Docker, or a release archive:
@@ -17,7 +23,7 @@ go install github.com/jeeftor/audiobook-organizer@latest
 
 See [Installation](INSTALLATION.md) for platform-specific options and package notes.
 
-## If You Use Audiobookshelf
+## 1. Configure Audiobookshelf
 
 <section class="media-callout">
   <a class="media-callout-image" href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/store_metadata.jpg" target="_blank" rel="noopener">
@@ -30,30 +36,7 @@ See [Installation](INSTALLATION.md) for platform-specific options and package no
   </div>
 </section>
 
-The normal ABS cycle is: configure sidecar metadata, preview, organize, scan ABS, clean up old missing paths if ABS still reports them, and keep the undo log until the library is verified.
-
-![Audiobookshelf organize lifecycle](abs-organize-lifecycle.svg)
-
-After the scan, ABS may still list old filesystem paths as missing. That is a normal cleanup step after moving files, not a failed organize run. Review the missing items in ABS, then use the missing-books cleanup action when the organized paths are already visible in the library.
-
-<section class="image-pair" aria-label="Audiobookshelf missing item cleanup screenshots">
-  <figure>
-    <a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/issues.jpg" target="_blank" rel="noopener">
-      <img src="issues.jpg" alt="Audiobookshelf issues view showing missing books">
-    </a>
-    <figcaption><a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/issues.jpg" target="_blank" rel="noopener">Open image</a> - review missing old paths in the ABS Issues view.</figcaption>
-  </figure>
-  <figure>
-    <a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/remove_books.jpg" target="_blank" rel="noopener">
-      <img src="remove_books.jpg" alt="Audiobookshelf remove missing books action">
-    </a>
-    <figcaption><a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/remove_books.jpg" target="_blank" rel="noopener">Open image</a> - remove missing entries after ABS has found the organized files.</figcaption>
-  </figure>
-</section>
-
-See [Audiobookshelf](audiobookshelf.md) for cleanup screenshots, path mapping checks, and scan commands.
-
-## Choose A Small Source Folder
+## 2. Preview With Dry Run
 
 Start with a small sample from your own library:
 
@@ -78,8 +61,6 @@ audiobook-organizer metadata --dir=/books/source --use-embedded-metadata
 
 For a flat folder of individual audiobook files, preview with `--flat` instead of the default directory-as-book behavior.
 
-## Preview First
-
 Run a dry run before moving files:
 
 ```bash
@@ -92,7 +73,7 @@ audiobook-organizer \
 
 Check the planned destination paths, metadata warnings, and skipped books. Dry-run mode does not mutate the filesystem.
 
-## Run For Real
+## 3. Organize
 
 When the preview looks right, remove `--dry-run`:
 
@@ -104,9 +85,36 @@ audiobook-organizer \
 
 The organizer writes `.abook-org.log` so the operation can be undone.
 
-## Undo If Needed
+## 4. Trigger Audiobookshelf Scan
 
-Undo the last organization operation from the source directory:
+After a non-dry-run organization, run or trigger an Audiobookshelf library scan so ABS can discover the organized paths and reconcile moved files.
+
+See [Audiobookshelf](audiobookshelf.md) for path mapping checks and scan commands.
+
+## 5. Clean Missing Items
+
+After the scan, ABS may still list old filesystem paths as missing. That is a normal cleanup step after moving files, not a failed organize run. Review the missing items in ABS, then use the missing-books cleanup action when the organized paths are already visible in the library.
+
+<section class="image-pair" aria-label="Audiobookshelf missing item cleanup screenshots">
+  <figure>
+    <a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/issues.jpg" target="_blank" rel="noopener">
+      <img src="issues.jpg" alt="Audiobookshelf issues view showing missing books">
+    </a>
+    <figcaption><a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/issues.jpg" target="_blank" rel="noopener">Open image</a> - review missing old paths in the ABS Issues view.</figcaption>
+  </figure>
+  <figure>
+    <a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/remove_books.jpg" target="_blank" rel="noopener">
+      <img src="remove_books.jpg" alt="Audiobookshelf remove missing books action">
+    </a>
+    <figcaption><a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/remove_books.jpg" target="_blank" rel="noopener">Open image</a> - remove missing entries after ABS has found the organized files.</figcaption>
+  </figure>
+</section>
+
+## 6. Verify And Keep The Undo Log
+
+Check the organized library in your filesystem and in Audiobookshelf before deleting the undo log. Keep `.abook-org.log` until you are satisfied with the result.
+
+If needed, undo the last organization operation from the source directory:
 
 ```bash
 audiobook-organizer --dir=/books/source --undo


### PR DESCRIPTION
Follow-up to #161 for #155.

## Summary
- Moves the Audiobookshelf lifecycle diagram to the top of Getting Started.
- Reorders the page into the same numbered sequence as the diagram:
  1. Configure Audiobookshelf
  2. Preview with dry run
  3. Organize
  4. Trigger Audiobookshelf scan
  5. Clean missing items
  6. Verify and keep the undo log
- Moves the missing-item cleanup screenshots into step 5 where they belong.

## Verification
- `make docs-verify`
- `git diff --cached --check`
- Rendered `output/docs-site/getting-started.html` with Chrome Headless Shell and reviewed the full-page screenshot locally.

## Docs / Changelog
- Updated `docs/getting-started.md`.
- No changelog change; #161 already added the user-visible docs entry for this Getting Started update.
