### PR TITLE
docs: remove visible image open links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,13 +100,13 @@ After the scan, ABS may still list old filesystem paths as missing. That is a no
     <a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/issues.jpg" target="_blank" rel="noopener">
       <img src="issues.jpg" alt="Audiobookshelf issues view showing missing books">
     </a>
-    <figcaption><a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/issues.jpg" target="_blank" rel="noopener">Open image</a> - review missing old paths in the ABS Issues view.</figcaption>
+    <figcaption>Review missing old paths in the ABS Issues view.</figcaption>
   </figure>
   <figure>
     <a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/remove_books.jpg" target="_blank" rel="noopener">
       <img src="remove_books.jpg" alt="Audiobookshelf remove missing books action">
     </a>
-    <figcaption><a href="https://github.com/jeeftor/audiobook-organizer/blob/master/docs/remove_books.jpg" target="_blank" rel="noopener">Open image</a> - remove missing entries after ABS has found the organized files.</figcaption>
+    <figcaption>Remove missing entries after ABS has found the organized files.</figcaption>
   </figure>
 </section>
 

--- a/web/scripts/build-docs-site.mjs
+++ b/web/scripts/build-docs-site.mjs
@@ -102,7 +102,7 @@ function linkStandaloneImages(html) {
     /<p><img src="([^"]+)" alt="([^"]*)"><\/p>/g,
     (_match, src, alt) => {
       const href = imageHref(src)
-      return `<figure class="doc-image"><a href="${href}" target="_blank" rel="noopener"><img src="${src}" alt="${alt}"></a><figcaption><a href="${href}" target="_blank" rel="noopener">Open image</a></figcaption></figure>`
+      return `<figure class="doc-image"><a href="${href}" target="_blank" rel="noopener"><img src="${src}" alt="${alt}"></a></figure>`
     },
   )
 }


### PR DESCRIPTION
Follow-up to #162 for #155.

## Summary
- Removes visible `Open image` caption links from generated standalone doc images.
- Keeps the images themselves clickable so users can still open the full-size asset.
- Replaces the Getting Started cleanup screenshot captions with plain explanatory text.

## Verification
- `make docs-verify`
- `git diff --cached --check`
- Rendered `output/docs-site/getting-started.html` locally and confirmed the visible `Open image` links are gone.

## Docs / Changelog
- Updated `docs/getting-started.md`.
- Updated `web/scripts/build-docs-site.mjs`.
- No changelog change; this is a small polish follow-up to the existing Getting Started docs update.
