### PR TITLE
docs: route README to generated docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved local web UI manual testing with a reusable template builder, colored layout/rename fields, relative local preview paths, completed move lists after execution, and automatic fallback from missing `metadata.json` previews to embedded file metadata.
 - Updated the layout guide and docs workflow to use public-domain book examples and added more table-based layout guidance.
 - Surfaced the Audiobookshelf lifecycle and missing-item cleanup screenshots on Getting Started and made the ABS metadata settings screenshot a compact side-by-side callout.
+- Clarified the README as a compact project landing page and added a prominent link to the generated documentation site.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ Audiobook Organizer is a single Go binary for previewing, organizing, renaming, 
 [![codecov](https://codecov.io/gh/jeeftor/audiobook-organizer/branch/master/graph/badge.svg)](https://codecov.io/gh/jeeftor/audiobook-organizer)
 [![Coverage Status](https://coveralls.io/repos/github/jeeftor/audiobook-organizer/badge.svg?branch=master)](https://coveralls.io/github/jeeftor/audiobook-organizer?branch=master)
 
+## [Open Documentation](https://jeeftor.github.io/audiobook-organizer/)
+
+Use this README as the quick project overview. The generated documentation site is the primary home for installation details, first-run guidance, workflow pages, troubleshooting, and generated screenshots/GIFs.
+
+[Getting Started](https://jeeftor.github.io/audiobook-organizer/getting-started.html) |
+[Installation](https://jeeftor.github.io/audiobook-organizer/installation.html) |
+[Choose An Interface](https://jeeftor.github.io/audiobook-organizer/interfaces.html) |
+[Audiobookshelf](https://jeeftor.github.io/audiobook-organizer/audiobookshelf.html)
+
 ![Audiobook Organizer web UI preview](https://jeeftor.github.io/audiobook-organizer/assets/generated/web-ui/web-ui-metadata-json-preview.png)
 
 ![Animated CLI organize run](https://jeeftor.github.io/audiobook-organizer/assets/generated/cli/cli-organize-run.gif)
@@ -179,7 +188,11 @@ audiobook-organizer abs scan \
 
 ## Documentation
 
-Published docs: <https://jeeftor.github.io/audiobook-organizer/>
+The generated documentation site is the canonical long-form guide:
+
+<https://jeeftor.github.io/audiobook-organizer/>
+
+The README should stay a compact GitHub landing page: what the tool does, how to install it, how to run safely, and where Audiobookshelf users must start. The docs site owns the full workflow pages, troubleshooting, detailed reference material, and generated visual demos.
 
 Repo docs:
 


### PR DESCRIPTION
Resolves #165.

## Findings
- The README had regained the important Audiobookshelf setup material and screenshots, but it still did not strongly route users to the generated docs site.
- The generated docs site now owns richer navigation, workflow pages, troubleshooting, and generated visuals better than the README can.
- The README should remain a GitHub landing page: project purpose, essential install/safe-run path, ABS setup visibility, and links to full docs.

## Summary
- Adds a prominent `Open Documentation` section near the top of the README.
- Links directly to generated Getting Started, Installation, Choose An Interface, and Audiobookshelf pages.
- Clarifies in the Documentation section that the generated docs site is the canonical long-form guide and README is the compact project overview.
- Adds a changelog entry for the README/docs-site routing change.

## Verification
- `make docs-verify`
- `git diff --check`
- `curl -fsSI` for the generated docs root plus Getting Started, Installation, Choose An Interface, and Audiobookshelf pages.

## Docs / Changelog
- Updated `README.md`.
- Updated `CHANGELOG.md`.
