### PR TITLE
Use Node 22 for web and docs CI installs

### DIFF
--- a/.github/workflows/docs-visuals.yml
+++ b/.github/workflows/docs-visuals.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '22'
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: '22'
         cache: npm
         cache-dependency-path: web/package-lock.json
 
@@ -134,7 +134,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: '22'
         cache: npm
         cache-dependency-path: web/package-lock.json
 


### PR DESCRIPTION
Refs #167

## Summary

- Pin the docs visual and web Playwright CI jobs to Node 22 instead of Node 24.
- Avoid the GitHub runner npm 11.12.1 `npm ci` failure seen after the Astro dependency expansion.
- Keep CI above Astro 6's Node `>=22.12.0` engine floor.

## Tests

- `git diff --check`
- `prek run --all-files`

Not run: `make docs-verify`, because this only changes GitHub Actions Node versions after the Starlight docs migration already passed local docs verification.

## Docs And Changelog

- No docs/changelog update; this is CI-only follow-up for the #167 publish path.
