### PR TITLE
chore: fix release hook formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — v0.12.0
+## [Unreleased]
+
+## [v0.13.1] — 2026-07-14
 
 ### Added
 

--- a/cmd/layout_template.go
+++ b/cmd/layout_template.go
@@ -58,8 +58,8 @@ EXAMPLES
     {author}/{series|Standalone}/{title}
 
   Include narrator in the book folder. (Placeholders get omitted when empty)
-    {author}/{series|Standalone}/{series-count} - {title} {(narrator)}    
-  
+    {author}/{series|Standalone}/{series-count} - {title} {(narrator)}
+
   Omit empty slash-separated segments automatically
     {author}/{series}/{title}
 


### PR DESCRIPTION
Resolves #188

## Summary

- Remove trailing whitespace from the layout-template help example so release pre-commit hooks do not rewrite the tracked file.

## Tests

- `prek run --all-files`
- `make test`

## Docs and changelog

- Added the `v0.13.1` release section and restored a clean `Unreleased` heading.
- User-facing documentation is already included in the feature commits being released.
- ABS matrix is not applicable.
