### PR TITLE
fix: document Docker web UI access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docker web UI access**: Documented the required `--host=0.0.0.0` bind,
+  container port publishing, token handling, and reverse-proxy backend port.
+
 ## [v0.13.1] — 2026-07-14
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,6 @@ FROM --platform=$TARGETPLATFORM alpine:latest
 WORKDIR /app
 COPY --from=builder /app/audiobook-organizer .
 
+EXPOSE 8080
+
 ENTRYPOINT ["/app/audiobook-organizer"]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ Docker:
 docker pull jeffsui/audiobook-organizer:latest
 ```
 
+To run the local web UI in Docker, bind the server to all container interfaces,
+publish the container port, and keep the session-token URL private:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v /path/to/audiobooks:/books \
+  -v /path/to/output:/output \
+  jeffsui/audiobook-organizer:latest \
+  web --host=0.0.0.0 --port=8080 --no-open
+```
+
+Open the tokenized URL printed in the container logs at
+`http://localhost:8080/`. When using Traefik or another reverse proxy, route
+to container port `8080`, not the host-side published port.
+
 Release archives and Linux packages are available from [GitHub Releases](https://github.com/jeeftor/audiobook-organizer/releases). See the [installation guide](docs/INSTALLATION.md) for package details and platform notes.
 
 ## Safe First Run

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -89,7 +89,21 @@ docker run --rm \
   jeffsui/audiobook-organizer --dir=/books --out=/output --dry-run
 ```
 
-The local web UI is primarily intended for host installs. For Docker, prefer CLI or TUI workflows unless you explicitly publish and secure a local port.
+To run the local web UI in Docker, bind the server to all container interfaces
+and publish the container port:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v /path/to/audiobooks:/books \
+  -v /path/to/output:/output \
+  jeffsui/audiobook-organizer:latest \
+  web --host=0.0.0.0 --port=8080 --no-open
+```
+
+Open the tokenized URL printed in the container logs at
+`http://localhost:8080/`. Keep that URL private. When using Traefik or another
+reverse proxy, route to container port `8080`, not the host-side published
+port.
 
 ### Go Install
 

--- a/web/src/content/docs/installation.md
+++ b/web/src/content/docs/installation.md
@@ -95,7 +95,21 @@ docker run --rm \
   jeffsui/audiobook-organizer --dir=/books --out=/output --dry-run
 ```
 
-The local web UI is primarily intended for host installs. For Docker, prefer CLI or TUI workflows unless you explicitly publish and secure a local port.
+To run the local web UI in Docker, bind the server to all container interfaces
+and publish the container port:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v /path/to/audiobooks:/books \
+  -v /path/to/output:/output \
+  jeffsui/audiobook-organizer:latest \
+  web --host=0.0.0.0 --port=8080 --no-open
+```
+
+Open the tokenized URL printed in the container logs at
+`http://localhost:8080/`. Keep that URL private. When using Traefik or another
+reverse proxy, route to container port `8080`, not the host-side published
+port.
 
 ### Go Install
 


### PR DESCRIPTION
Relates to #187

## Summary

- Document the explicit `0.0.0.0` bind and published container port required for Docker web UI access.
- Expose container port 8080 and document Traefik/reverse-proxy routing plus token handling.

## Tests

- `make docs-verify`
- `prek run --files Dockerfile README.md docs/INSTALLATION.md web/src/content/docs/installation.md CHANGELOG.md`
- Built `audiobook-organizer:issue-187`, ran `web --host=0.0.0.0 --port=8080 --no-open` with `18080:8080`, and fetched the tokenized UI through `http://127.0.0.1:18080/`.

## Docs and changelog

- Updated README, root installation docs, mirrored docs-site installation page, and `CHANGELOG.md`.
- ABS matrix is not applicable.

## Reporter follow-up

- This user-originated report needs the reporter to verify their Traefik/Authelia deployment before closure.
