### PR TITLE
chore: restore release formatting gate

### DIFF
--- a/internal/organizer/template.go
+++ b/internal/organizer/template.go
@@ -214,7 +214,10 @@ func normalizeCompositeContentForFieldScan(content string) string {
 	return strings.ReplaceAll(content, "-", "_")
 }
 
-func findFieldReferenceAt(content string, start int) (fieldName, format string, fieldStart, fieldEnd int, found bool) {
+func findFieldReferenceAt(
+	content string,
+	start int,
+) (fieldName, format string, fieldStart, fieldEnd int, found bool) {
 	scanContent := normalizeCompositeContentForFieldScan(content)
 	earliest := -1
 
@@ -288,7 +291,10 @@ func (tr *TemplateRenderer) Render(metadata Metadata) (string, error) {
 	return result.String(), nil
 }
 
-func (tr *TemplateRenderer) renderCompositeToken(token templateToken, metadata Metadata) (string, error) {
+func (tr *TemplateRenderer) renderCompositeToken(
+	token templateToken,
+	metadata Metadata,
+) (string, error) {
 	for _, part := range token.composite {
 		if !part.isField {
 			continue
@@ -313,7 +319,10 @@ func (tr *TemplateRenderer) renderCompositeToken(token templateToken, metadata M
 	return result.String(), nil
 }
 
-func (tr *TemplateRenderer) resolveFieldFormatted(fieldName, format string, metadata Metadata) string {
+func (tr *TemplateRenderer) resolveFieldFormatted(
+	fieldName, format string,
+	metadata Metadata,
+) string {
 	value := tr.resolveField(fieldName, metadata)
 	return applyNumericFormat(value, format)
 }

--- a/internal/tui/models/settings_redesign.go
+++ b/internal/tui/models/settings_redesign.go
@@ -1069,7 +1069,13 @@ func (m *SettingsTableModel) renderPopup() string {
 			if option == "custom" {
 				layoutTemplate = m.layoutTemplate
 			}
-			previewPath := GenerateOutputPath(*currentBook, option, layoutTemplate, fieldMapping, "output")
+			previewPath := GenerateOutputPath(
+				*currentBook,
+				option,
+				layoutTemplate,
+				fieldMapping,
+				"output",
+			)
 
 			// Colorize the preview
 			coloredPreview := m.colorizeOutputPath(previewPath, option)


### PR DESCRIPTION
## Summary

- apply the repository golines formatting required by release CI
- restore a clean pre-commit release gate

## Verification

- prek run --all-files
- CI: Go, ABS matrix, browser suites, and session-token regression passed

## Docs and changelog

Not applicable: formatting-only maintenance with no user-visible behavior change.

Resolves #192