### PR TITLE
ci: publish successful Playwright evidence artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,11 +102,12 @@ jobs:
     - name: Run Playwright web UI tests
       run: make gui-test
 
-    - name: Upload Playwright artifacts on failure
-      if: failure()
+    - name: Upload Playwright evidence
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: web-ui-playwright-artifacts
+        retention-days: 14
         path: |
           web/playwright-report/**
           web/test-results/**
@@ -274,11 +275,12 @@ jobs:
       if: always()
       run: docker compose -f test/abs/docker-compose.yml down --remove-orphans
 
-    - name: Upload ABS Playwright artifacts on failure
-      if: failure()
+    - name: Upload ABS Playwright evidence
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: web-ui-abs-playwright-artifacts
+        retention-days: 14
         path: |
           web/playwright-report/**
           web/test-results/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Successful web UI test evidence**: GitHub browser jobs now retain Playwright reports, final screenshots, and a per-test evidence summary for green runs as well as failures.
 - **ABS metadata-source organize workflow**: The local web UI can now organize an Audiobookshelf-mounted library directly from validated ABS metadata, with the normal dry-run preview, selected-move review, run log, and ABS scan/cleanup follow-up.
 - **Web metadata field mapping**: The organize and rename setup screens now offer
   source presets and editable title, author, series, track, and disc mappings;

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -10,10 +10,16 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  reporter: process.env.CI
+    ? [
+        ['list'],
+        ['html', { open: 'never' }],
+        ['./tests/e2e/evidence-reporter.ts'],
+      ]
+    : [['list']],
   use: {
     trace: 'retain-on-failure',
-    screenshot: 'only-on-failure',
+    screenshot: process.env.CI ? 'on' : 'only-on-failure',
     video: 'retain-on-failure',
   },
   projects: [

--- a/web/tests/e2e/evidence-reporter.ts
+++ b/web/tests/e2e/evidence-reporter.ts
@@ -1,0 +1,44 @@
+import type { FullConfig, FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, relative } from 'node:path'
+
+type EvidenceRecord = {
+  test: string
+  project: string
+  outcome: string
+  duration_ms: number
+  evidence: string[]
+}
+
+const summaryPath = 'test-results/ui-e2e-summary.json'
+
+class EvidenceReporter implements Reporter {
+  private readonly records = new Map<string, EvidenceRecord>()
+
+  onBegin(_config: FullConfig): void {
+    mkdirSync(dirname(summaryPath), { recursive: true })
+  }
+
+  onTestEnd(test: TestCase, result: TestResult): void {
+    const evidence = result.attachments
+      .filter((attachment) => attachment.path)
+      .map((attachment) => relative(process.cwd(), attachment.path!))
+
+    const project = test.parent.project()?.name ?? 'unknown'
+    const title = test.titlePath().filter(Boolean).join(' > ')
+
+    this.records.set(`${project}:${title}`, {
+      test: title,
+      project,
+      outcome: result.status,
+      duration_ms: result.duration,
+      evidence,
+    })
+  }
+
+  onEnd(_result: FullResult): void {
+    writeFileSync(summaryPath, `${JSON.stringify({ generated_at: new Date().toISOString(), tests: [...this.records.values()] }, null, 2)}\n`)
+  }
+}
+
+export default EvidenceReporter


### PR DESCRIPTION
Resolves #200

## Summary

- Retain a final screenshot for every CI Playwright test.
- Generate a sanitized per-test evidence summary.
- Upload reports and evidence for successful and failed UI jobs with 14-day retention.

## Verification

- `make web-build`
- `CI=1 npx playwright test tests/e2e/organize-real.spec.ts --project=chromium-desktop --grep 'runs only selected organize preview rows'`
- `prek run --all-files`

## Docs and changelog

- Added an Unreleased changelog entry; no user-facing docs update required.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jeeftor/audiobook-organizer/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->